### PR TITLE
Auto-deploy master to Vercel production on every push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy master to production
+
+# Always deploy the latest master commit to Vercel production
+# (adamklockars.com). This runs independently of Vercel's own Git
+# integration, so it is not affected by deployment deduplication or
+# missed webhooks — every push to master triggers a fresh production build.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {} # allow manual redeploys from the Actions tab
+
+# Only one production deploy at a time; newest push wins.
+concurrency:
+  group: vercel-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel production deploy
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "::error::VERCEL_DEPLOY_HOOK_URL secret is not set."
+            echo "Create a Vercel Deploy Hook for the 'master' branch"
+            echo "(Project → Settings → Git → Deploy Hooks) and add its URL"
+            echo "as a repository secret named VERCEL_DEPLOY_HOOK_URL."
+            exit 1
+          fi
+          # Deploy Hooks always build, and since master is the production
+          # branch the resulting deployment is promoted to production.
+          curl -fsS --retry 3 -X POST "$DEPLOY_HOOK_URL" -o response.json
+          echo "Triggered Vercel production deployment for master:"
+          cat response.json


### PR DESCRIPTION
Adds `.github/workflows/deploy.yml` so **every push to `master`** (plus manual `workflow_dispatch` runs) triggers a Vercel **production** deployment to `adamklockars.com`.

## Why
The squash-merge of #9 never produced a production deployment — Vercel's deployment **deduplication** skipped it (the merge's file tree was identical to a preview it had already built), so production stayed on the May-25 build. This workflow makes deploys explicit and repo-controlled, independent of Vercel's Git integration, so a master change can never silently fail to deploy again.

## How it works
The job POSTs to a Vercel **Deploy Hook**. Deploy Hooks always build (bypassing dedup), and since `master` is the production branch, the result is promoted to production.

## Required setup (one-time, manual — needs Vercel + repo admin)
1. **Vercel** → project `adamklockars` → **Settings → Git → Deploy Hooks** → create a hook: name `master-prod`, branch `master` → copy the URL.
2. **GitHub** → repo **Settings → Secrets and variables → Actions → New repository secret** → name `VERCEL_DEPLOY_HOOK_URL`, value = the hook URL.
3. Merge this PR. The merge itself is a push to `master`, so it triggers the first production deploy (publishing the games + the updated copy from #9).

If the secret isn't set, the workflow fails fast with an explanatory message rather than deploying nothing silently.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_