### PR TITLE
Rework If Then Explosion into a retro green Turing-style cave-flyer

### DIFF
--- a/app/side-scroller/page.tsx
+++ b/app/side-scroller/page.tsx
@@ -5,7 +5,7 @@ import SideScroller from "@/components/sidescroller/SideScroller";
 export const metadata: Metadata = {
   title: "If Then Explosion — Adam Klockars",
   description:
-    "A retro side-scroller rebuilt from the original Turing spaceship game. Steer through scrolling walls and dodge dropping aliens — the level always has a safe path.",
+    "A retro green cave-flyer rebuilt from the original Turing spaceship game. Thread a triangle ship through walls that pinch toward the centre while aliens squeeze the gap — the level always leaves a safe path.",
 };
 
 export default function SideScrollerPage() {
@@ -20,8 +20,8 @@ export default function SideScrollerPage() {
           If Then Explosion
         </h1>
         <p className="mt-3 max-w-md text-center text-muted">
-          A retro side-scroller, rebuilt from the spaceship game I first wrote in
-          Turing. Thread the scrolling gaps, dodge the aliens.
+          A retro green cave-flyer, rebuilt from the triangle-ship game I first
+          wrote in Turing. Thread the pinching cave, dodge the aliens.
         </p>
 
         <div className="mt-12 w-full">

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -15,7 +15,7 @@ const experiments = [
     href: "/side-scroller",
     title: "If Then Explosion",
     blurb:
-      "A retro side-scroller rebuilt from the spaceship game I first wrote in Turing. Fly through the scrolling gaps and dodge dropping aliens — the level always leaves a safe path.",
+      "A retro green cave-flyer rebuilt from the spaceship game I first wrote in Turing. Thread the triangle ship through walls that pinch toward the centre while aliens squeeze the gap — there's always a way through.",
     icon: Rocket,
     accent: "#48e0a0",
   },

--- a/components/sidescroller/SideScroller.tsx
+++ b/components/sidescroller/SideScroller.tsx
@@ -5,8 +5,6 @@ import { ChevronUp, ChevronDown, RotateCcw, Play } from "lucide-react";
 import {
   VIRT,
   SHIP,
-  WALL_W,
-  GAP,
   ALIEN_R,
   type World,
   type Input,
@@ -14,14 +12,21 @@ import {
   updateWorld,
   scoreOf,
   alienY,
+  caveBounds,
 } from "@/lib/sidescroller";
 
 type Phase = "menu" | "playing" | "dead";
 
 const BEST_KEY = "sidescroller-best";
-const ACCENT = "#7c6cff";
 
-type Star = { x: number; y: number; z: number };
+// Retro green CRT palette.
+const GREEN = "#39ff6a"; // bright phosphor green
+const GREEN_DIM = "#1f9c47";
+const WALL_FILL = "#0c3a1d";
+const WALL_EDGE = "#36e063";
+const PX = 8; // chunky pixel grid for the cave walls
+
+type Fleck = { x: number; y: number; z: number };
 
 export default function SideScroller() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -29,11 +34,10 @@ export default function SideScroller() {
   const [score, setScore] = useState(0);
   const [best, setBest] = useState(0);
 
-  // Mutable game refs (kept out of React state so the rAF loop is allocation-free).
   const worldRef = useRef<World | null>(null);
   const inputRef = useRef<Input>({ up: false, down: false });
   const phaseRef = useRef<Phase>("menu");
-  const starsRef = useRef<Star[]>([]);
+  const flecksRef = useRef<Fleck[]>([]);
   const rafRef = useRef<number>(0);
   const lastRef = useRef<number>(0);
 
@@ -84,7 +88,7 @@ export default function SideScroller() {
     };
   }, [start]);
 
-  // Render + simulation loop.
+  // Simulation + render loop.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -96,29 +100,28 @@ export default function SideScroller() {
     canvas.height = VIRT.H * dpr;
     ctx.scale(dpr, dpr);
 
-    // Build the parallax starfield once.
-    if (starsRef.current.length === 0) {
-      const stars: Star[] = [];
-      for (let i = 0; i < 90; i++) {
-        stars.push({
+    // Faint drifting flecks for depth (very subtle, green).
+    if (flecksRef.current.length === 0) {
+      const flecks: Fleck[] = [];
+      for (let i = 0; i < 50; i++) {
+        flecks.push({
           x: Math.random() * VIRT.W,
           y: Math.random() * VIRT.H,
-          z: 0.3 + Math.random() * 0.7, // depth → speed & size
+          z: 0.3 + Math.random() * 0.7,
         });
       }
-      starsRef.current = stars;
+      flecksRef.current = flecks;
     }
 
     const loop = (ts: number) => {
       rafRef.current = requestAnimationFrame(loop);
       const last = lastRef.current || ts;
-      const dt = Math.min(0.05, (ts - last) / 1000); // clamp big gaps (tab switches)
+      const dt = Math.min(0.05, (ts - last) / 1000);
       lastRef.current = ts;
 
       const playing = phaseRef.current === "playing";
       const world = worldRef.current;
 
-      // --- update ---
       if (playing && world) {
         updateWorld(world, dt, inputRef.current);
         if (world.dead) {
@@ -131,30 +134,27 @@ export default function SideScroller() {
           });
           setPhase("dead");
         } else if (Math.random() < 0.2) {
-          // throttle React updates: refresh the HUD score occasionally
           setScore(scoreOf(world));
         }
       }
 
-      // starfield always drifts (even on menus) for ambiance
-      const starSpeed = world && playing ? world.speed : 120;
-      const stars = starsRef.current;
-      for (const st of stars) {
-        st.x -= starSpeed * st.z * dt;
-        if (st.x < 0) {
-          st.x = VIRT.W;
-          st.y = Math.random() * VIRT.H;
+      const driftSpeed = world && playing ? world.speed : 90;
+      const flecks = flecksRef.current;
+      for (const f of flecks) {
+        f.x -= driftSpeed * f.z * dt;
+        if (f.x < 0) {
+          f.x = VIRT.W;
+          f.y = Math.random() * VIRT.H;
         }
       }
 
-      draw(ctx, world, stars, playing || phaseRef.current === "dead");
+      draw(ctx, world, flecks, playing || phaseRef.current === "dead");
     };
 
     rafRef.current = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(rafRef.current);
   }, []);
 
-  // Pointer controls — hold the upper/lower half of the board, or the buttons.
   const setDir = (dir: "up" | "down" | null) => {
     inputRef.current.up = dir === "up";
     inputRef.current.down = dir === "down";
@@ -171,19 +171,25 @@ export default function SideScroller() {
       <div className="mb-4 flex items-center justify-between font-mono text-sm">
         <span className="text-muted">
           Score{" "}
-          <span className="tabular-nums font-semibold text-foreground">
+          <span className="tabular-nums font-semibold" style={{ color: GREEN }}>
             {score}
           </span>
         </span>
         <span className="text-muted">
           Best{" "}
-          <span className="tabular-nums font-semibold text-accent">{best}</span>
+          <span className="tabular-nums font-semibold" style={{ color: GREEN }}>
+            {best}
+          </span>
         </span>
       </div>
 
       <div
-        className="relative overflow-hidden rounded-2xl border border-border bg-black shadow-[0_0_80px_-30px_var(--color-accent)]"
-        style={{ aspectRatio: `${VIRT.W} / ${VIRT.H}`, touchAction: "none" }}
+        className="relative overflow-hidden rounded-2xl border border-border bg-black"
+        style={{
+          aspectRatio: `${VIRT.W} / ${VIRT.H}`,
+          touchAction: "none",
+          boxShadow: `0 0 80px -30px ${GREEN}`,
+        }}
         onPointerDown={onPointer}
         onPointerMove={(e) => e.buttons && onPointer(e)}
         onPointerUp={() => setDir(null)}
@@ -192,37 +198,53 @@ export default function SideScroller() {
         <canvas ref={canvasRef} className="block h-full w-full" />
 
         {phase !== "playing" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/55 backdrop-blur-sm">
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/65 backdrop-blur-sm">
             {phase === "menu" ? (
               <>
-                <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
-                  Retro
+                <p
+                  className="font-mono text-xs uppercase tracking-[0.3em]"
+                  style={{ color: GREEN }}
+                >
+                  Retro · Turing
                 </p>
-                <h2 className="mt-2 font-display text-3xl font-bold sm:text-4xl">
+                <h2
+                  className="mt-2 font-display text-3xl font-bold sm:text-4xl"
+                  style={{ color: GREEN }}
+                >
                   If Then Explosion
                 </h2>
                 <p className="mt-3 max-w-xs text-center text-sm text-muted">
-                  Fly the ship through the gaps and dodge the aliens. Up / Down
-                  arrows (or W / S) — on touch, hold the top or bottom of the
-                  screen.
+                  Fly the triangle through the cave. The walls close toward the
+                  centre and aliens squeeze the gap — but there&apos;s always a
+                  way through. Up / Down arrows (or W / S); on touch, hold the
+                  top or bottom.
                 </p>
               </>
             ) : (
               <>
-                <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
-                  Game over
+                <p
+                  className="font-mono text-xs uppercase tracking-[0.3em]"
+                  style={{ color: "#ff5d5d" }}
+                >
+                  Boom
                 </p>
-                <h2 className="mt-2 font-display text-3xl font-bold sm:text-4xl">
+                <h2
+                  className="mt-2 font-display text-3xl font-bold sm:text-4xl"
+                  style={{ color: GREEN }}
+                >
                   {score} <span className="text-muted">pts</span>
                 </h2>
                 {score >= best && score > 0 && (
-                  <p className="mt-1 text-sm text-accent">New best! 🎉</p>
+                  <p className="mt-1 text-sm" style={{ color: GREEN }}>
+                    New best! 🟢
+                  </p>
                 )}
               </>
             )}
             <button
               onClick={start}
-              className="mt-6 inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3 font-medium text-background transition-transform hover:scale-[1.03] active:scale-95"
+              className="mt-6 inline-flex items-center gap-2 rounded-full px-7 py-3 font-medium text-black transition-transform hover:scale-[1.03] active:scale-95"
+              style={{ background: GREEN }}
             >
               {phase === "menu" ? (
                 <Play className="size-4" />
@@ -246,7 +268,7 @@ export default function SideScroller() {
       </div>
 
       <p className="mt-4 hidden text-center font-mono text-xs text-faint sm:block">
-        ↑ / ↓ or W / S to steer · the gaps and aliens are generated so a safe
+        ↑ / ↓ or W / S to steer · the cave and aliens are generated so a safe
         path always exists
       </p>
     </div>
@@ -281,69 +303,52 @@ function HoldButton({
 }
 
 // --------------------------------------------------------------------------
-// Canvas drawing
+// Canvas drawing — retro green CRT
 // --------------------------------------------------------------------------
 function draw(
   ctx: CanvasRenderingContext2D,
   world: World | null,
-  stars: Star[],
+  flecks: Fleck[],
   showWorld: boolean,
 ) {
-  // Background: deep space gradient.
-  const g = ctx.createLinearGradient(0, 0, 0, VIRT.H);
-  g.addColorStop(0, "#05050c");
-  g.addColorStop(1, "#0b0716");
-  ctx.fillStyle = g;
+  // Dark green-black background.
+  ctx.fillStyle = "#02140a";
   ctx.fillRect(0, 0, VIRT.W, VIRT.H);
 
-  // Stars.
-  for (const st of stars) {
-    ctx.globalAlpha = 0.25 + st.z * 0.6;
-    ctx.fillStyle = st.z > 0.75 ? "#c9c4ff" : "#6b6b80";
-    const s = st.z * 2.2;
-    ctx.fillRect(st.x, st.y, s, s);
+  // Faint drifting flecks.
+  for (const f of flecks) {
+    ctx.globalAlpha = 0.06 + f.z * 0.12;
+    ctx.fillStyle = GREEN_DIM;
+    ctx.fillRect(Math.floor(f.x), Math.floor(f.y), 2, 2);
   }
   ctx.globalAlpha = 1;
 
-  if (!world || !showWorld) return;
-
-  // Walls — neon barriers with a glowing edge around the gap.
-  for (const wall of world.walls) {
-    const gapTop = wall.center - GAP / 2;
-    const gapBot = wall.center + GAP / 2;
-    drawWallSlab(ctx, wall.x, 0, gapTop);
-    drawWallSlab(ctx, wall.x, gapBot, VIRT.H - gapBot);
+  if (world && showWorld) {
+    drawCave(ctx, world);
+    for (const a of world.aliens) drawAlien(ctx, a.x, alienY(world, a), a.entry);
+    drawShip(ctx, world);
   }
 
-  // Aliens.
-  for (const a of world.aliens) {
-    drawAlien(ctx, a.x, alienY(world, a), a.entry);
-  }
-
-  // Ship.
-  drawShip(ctx, SHIP.X, world.shipY, world.dead);
+  drawScanlines(ctx);
 }
 
-function drawWallSlab(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  h: number,
-) {
-  if (h <= 0) return;
-  const grad = ctx.createLinearGradient(x, 0, x + WALL_W, 0);
-  grad.addColorStop(0, "#2a2150");
-  grad.addColorStop(0.5, "#4a3aa0");
-  grad.addColorStop(1, "#2a2150");
-  ctx.fillStyle = grad;
-  ctx.fillRect(x, y, WALL_W, h);
-  // Glowing inner edge facing the gap.
-  ctx.fillStyle = ACCENT;
-  ctx.shadowColor = ACCENT;
-  ctx.shadowBlur = 16;
-  const edgeY = y === 0 ? y + h - 4 : y;
-  ctx.fillRect(x, edgeY, WALL_W, 4);
-  ctx.shadowBlur = 0;
+// The continuous cave: chunky pixel columns from each edge to the wall surface.
+function drawCave(ctx: CanvasRenderingContext2D, world: World) {
+  for (let x = 0; x < VIRT.W; x += PX) {
+    const { top, bottom } = caveBounds(world, world.distance + x + PX / 2);
+    const topQ = Math.max(0, Math.round(top / PX) * PX);
+    const botQ = Math.min(VIRT.H, Math.round(bottom / PX) * PX);
+
+    // Wall bodies.
+    ctx.fillStyle = WALL_FILL;
+    if (topQ > 0) ctx.fillRect(x, 0, PX, topQ);
+    if (botQ < VIRT.H) ctx.fillRect(x, botQ, PX, VIRT.H - botQ);
+
+    // Bright phosphor edge along the passage.
+    ctx.fillStyle = WALL_EDGE;
+    if (topQ > 0) ctx.fillRect(x, topQ - PX, PX, PX);
+    if (botQ < VIRT.H) ctx.fillRect(x, botQ, PX, PX);
+  }
 }
 
 function drawAlien(
@@ -354,69 +359,66 @@ function drawAlien(
 ) {
   ctx.save();
   ctx.translate(x, y);
-  ctx.globalAlpha = 0.3 + 0.7 * Math.min(1, entry);
-  // Classic invader silhouette as a chunky pixel blob.
-  ctx.fillStyle = "#48e0a0";
-  ctx.shadowColor = "#48e0a0";
-  ctx.shadowBlur = 12;
-  const p = ALIEN_R / 4; // pixel unit
-  // body
+  const s = 0.4 + 0.6 * Math.min(1, entry);
+  ctx.scale(s, s);
+  ctx.globalAlpha = Math.min(1, entry + 0.3);
+
+  // Chunky invader, a touch lighter than the walls so it reads as a hazard.
+  ctx.fillStyle = "#9dff66";
+  ctx.shadowColor = "#9dff66";
+  ctx.shadowBlur = 8;
+  const p = ALIEN_R / 4;
   ctx.fillRect(-3 * p, -2 * p, 6 * p, 4 * p);
-  // head bump
   ctx.fillRect(-2 * p, -3 * p, 4 * p, p);
-  // legs
   ctx.fillRect(-3 * p, 2 * p, p, 1.5 * p);
   ctx.fillRect(2 * p, 2 * p, p, 1.5 * p);
   ctx.shadowBlur = 0;
-  // eyes
-  ctx.fillStyle = "#05050c";
+  // Dark eyes.
+  ctx.fillStyle = "#02140a";
   ctx.fillRect(-1.6 * p, -1.2 * p, p, p);
   ctx.fillRect(0.6 * p, -1.2 * p, p, p);
   ctx.restore();
 }
 
-function drawShip(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  dead: boolean,
-) {
+function drawShip(ctx: CanvasRenderingContext2D, world: World) {
+  const x = SHIP.X;
+  const y = world.shipY;
   ctx.save();
   ctx.translate(x, y);
 
-  // Thruster flame (flickers).
-  if (!dead) {
-    const flame = 10 + Math.random() * 8;
-    const fg = ctx.createLinearGradient(-SHIP.W / 2 - flame, 0, -SHIP.W / 2, 0);
-    fg.addColorStop(0, "rgba(255,160,40,0)");
-    fg.addColorStop(1, "#ffb030");
-    ctx.fillStyle = fg;
+  // Thruster flicker.
+  if (!world.dead) {
+    const flame = 8 + Math.random() * 7;
+    ctx.fillStyle = "rgba(57,255,106,0.5)";
     ctx.beginPath();
-    ctx.moveTo(-SHIP.W / 2, -5);
-    ctx.lineTo(-SHIP.W / 2 - flame, 0);
-    ctx.lineTo(-SHIP.W / 2, 5);
+    ctx.moveTo(-SHIP.TAIL, -4);
+    ctx.lineTo(-SHIP.TAIL - flame, 0);
+    ctx.lineTo(-SHIP.TAIL, 4);
     ctx.closePath();
     ctx.fill();
   }
 
-  // Hull — sleek arrow.
-  ctx.fillStyle = dead ? "#7a2740" : "#d6d3ff";
-  ctx.shadowColor = dead ? "#ff4d6d" : ACCENT;
-  ctx.shadowBlur = 18;
+  // The ship — a simple triangle, just like the Turing original.
+  ctx.lineJoin = "round";
   ctx.beginPath();
-  ctx.moveTo(SHIP.W / 2, 0);
-  ctx.lineTo(-SHIP.W / 2, -SHIP.H / 2);
-  ctx.lineTo(-SHIP.W / 3, 0);
-  ctx.lineTo(-SHIP.W / 2, SHIP.H / 2);
+  ctx.moveTo(SHIP.NOSE, 0);
+  ctx.lineTo(-SHIP.TAIL, -SHIP.HALF_H);
+  ctx.lineTo(-SHIP.TAIL, SHIP.HALF_H);
   ctx.closePath();
+  ctx.fillStyle = world.dead ? "#7a2740" : "rgba(57,255,106,0.18)";
   ctx.fill();
+  ctx.strokeStyle = world.dead ? "#ff5d6d" : GREEN;
+  ctx.shadowColor = world.dead ? "#ff5d6d" : GREEN;
+  ctx.shadowBlur = 10;
+  ctx.lineWidth = 2;
+  ctx.stroke();
   ctx.shadowBlur = 0;
 
-  // Cockpit.
-  ctx.fillStyle = ACCENT;
-  ctx.beginPath();
-  ctx.arc(SHIP.W / 8, 0, 4, 0, Math.PI * 2);
-  ctx.fill();
-
   ctx.restore();
+}
+
+// CRT scanlines overlay.
+function drawScanlines(ctx: CanvasRenderingContext2D) {
+  ctx.fillStyle = "rgba(0,0,0,0.16)";
+  for (let y = 0; y < VIRT.H; y += 3) ctx.fillRect(0, y, VIRT.W, 1);
 }

--- a/lib/sidescroller.ts
+++ b/lib/sidescroller.ts
@@ -1,73 +1,85 @@
-// Game logic for the retro side-scroller — a rebuild of the old Turing
-// spaceship game from the original site. Pure-ish module: all the rules,
-// generation, and physics live here so the React component is just a renderer.
+// Game logic for "If Then Explosion" — a rebuild of the spaceship game I first
+// wrote in Turing. The original was a triangle ship flying through a scrolling
+// green cave, with collision done by "looking ahead" at the colour of the
+// pixels in front of the ship. This keeps that spirit: a continuous cave whose
+// walls swell toward the centre to pinch the passage, aliens that squeeze the
+// gap further, and look-ahead collision sampling at the ship's nose/corners.
 //
-// The headline invariant (see `verifyPassable`): there is ALWAYS a continuous,
-// physically-reachable path through the level. We achieve this with a "safe
-// corridor" — a band of fixed height `GAP` whose centre drifts slowly. Every
-// wall's opening is aligned to that band, and every alien is kept fully outside
-// it, so the corridor is never blocked and the ship can always thread through.
+// Passability guarantee (see `verifyPassable`): a clear, reachable "safe lane"
+// of fixed height always runs through the level. The cave walls never close in
+// past that lane, aliens are always kept just outside it, and the lane's centre
+// drifts slowly enough that the ship can always follow it. So however tight it
+// looks, a path always exists.
 
-// Fixed virtual coordinate space; the renderer scales this to the canvas.
 export const VIRT = { W: 960, H: 540 } as const;
 
-// Ship --------------------------------------------------------------------
+// Ship — a simple right-pointing triangle (nose ahead, two tail corners).
 export const SHIP = {
-  X: 170, // fixed horizontal position; the world scrolls past it
-  W: 42,
-  H: 24,
+  X: 180, // fixed screen x; the cave scrolls past
+  NOSE: 18, // nose extends this far ahead of X
+  TAIL: 14, // tail sits this far behind X
+  HALF_H: 11, // half the tail height (collision half-height)
   SPEED: 300, // px/s vertical travel while a key is held
 } as const;
 
-// Walls -------------------------------------------------------------------
-export const WALL_W = 48; // thickness of each vertical barrier
-export const SPACING = 320; // centre-to-centre distance between walls
-export const GAP = 170; // height of the opening (== safe-corridor height)
+// Safe lane — the guaranteed-clear corridor the player threads.
+export const SAFE_HALF = 26; // half-height of the always-clear lane (> ship)
 
-// The corridor centre is clamped so that an alien parked just outside the
-// band (on either side) still fits fully on-screen — keeps the guarantee
-// visually honest as well as logically true.
-export const ALIEN_R = 16;
-const ALIEN_OFFSET = GAP / 2 + ALIEN_R + 12; // band edge → alien centre
-export const CORRIDOR_MIN = ALIEN_OFFSET + ALIEN_R; // 405 → top room for a low alien
-export const CORRIDOR_MAX = VIRT.H - (ALIEN_OFFSET + ALIEN_R);
+// Aliens hug just outside the lane, in the slack between lane and wall.
+export const ALIEN_R = 14;
+const ALIEN_OFFSET = SAFE_HALF + ALIEN_R + 6; // lane-edge → alien centre
+const ALIEN_BOB = 4; // idle bob amplitude (kept < the lane clearance)
 
-// Difficulty: scroll speed ramps with distance, capped.
-const SPEED_BASE = 190;
-const SPEED_MAX = 360;
-const SPEED_RAMP = 1 / 70; // +1 px/s of speed per 70px travelled
+// Cave walls. The passage half-height oscillates between PINCH (walls swollen
+// toward the centre — just enough room for the lane plus a flanking alien) and
+// OPEN (walls receded). It never drops below the lane.
+const HALF_PINCH = SAFE_HALF + 2 * ALIEN_R + 6; // 60 — narrowest passage half
+const HALF_OPEN = SAFE_HALF + 130; // 156 — widest passage half
 
-// Aliens spawn on a timer that tightens slightly as you go.
-const ALIEN_INTERVAL_START = 2.0; // seconds
-const ALIEN_INTERVAL_MIN = 0.95;
-const ALIEN_ENTRY = 0.45; // seconds for the "drop in" animation
+// Lane centre wanders within this band so the full-width walls stay on screen.
+const C_MID = VIRT.H / 2;
+const C_MIN = HALF_OPEN + 6;
+const C_MAX = VIRT.H - HALF_OPEN - 6;
+// Centre wobble: amplitude/wavelength pairs. The summed max slope
+// (A1/L1 + A2/L2) is bounded so the ship can always out-climb the lane.
+const C_A1 = 60,
+  C_L1 = 200,
+  C_A2 = 26,
+  C_L2 = 115;
+// Passage-width wobble wavelengths.
+const H_L1 = 240,
+  H_L2 = 130;
 
-export type Wall = {
-  x: number; // world x of the wall's left edge
-  center: number; // corridor centre at this wall (== gap centre)
-  scored: boolean;
-};
+// Difficulty: scroll speed ramps with distance.
+const SPEED_BASE = 175;
+const SPEED_MAX = 330;
+const SPEED_RAMP = 1 / 80;
+
+const ALIEN_INTERVAL_START = 1.8;
+const ALIEN_INTERVAL_MIN = 0.85;
+const ALIEN_ENTRY = 0.4;
 
 export type Alien = {
-  x: number;
-  offset: number; // signed distance from corridor centre (kept outside the band)
-  entry: number; // 0→1 entry animation progress
-  fromY: number; // off-screen y the alien eases in from
-  wobble: number; // phase for a little idle bob
+  x: number; // screen x
+  side: 1 | -1; // -1 above the lane, +1 below
+  entry: number; // 0→1 entry animation
+  wobble: number;
 };
 
 export type World = {
   shipY: number;
   vy: number;
-  distance: number; // total px scrolled — drives score & difficulty
+  distance: number;
   speed: number;
-  walls: Wall[];
   aliens: Alien[];
-  nextWallX: number; // world x at which to place the next wall
-  lastCenter: number;
   alienTimer: number;
   dead: boolean;
   rng: () => number;
+  // Deterministic terrain phases (seeded).
+  p1: number;
+  p2: number;
+  p3: number;
+  p4: number;
 };
 
 export type Input = { up: boolean; down: boolean };
@@ -75,8 +87,6 @@ export type Input = { up: boolean; down: boolean };
 const clamp = (v: number, lo: number, hi: number) =>
   v < lo ? lo : v > hi ? hi : v;
 
-// Small seeded PRNG (mulberry32) so levels are deterministic and the
-// passability guarantee is reproducible/testable.
 function mulberry32(seed: number): () => number {
   let a = seed >>> 0;
   return () => {
@@ -92,132 +102,93 @@ function speedAt(distance: number): number {
   return Math.min(SPEED_MAX, SPEED_BASE + distance * SPEED_RAMP);
 }
 
-// How far the corridor centre may shift between two consecutive walls.
-// Bounded by BOTH (a) what the ship can climb/descend over that horizontal
-// span — guaranteeing reachability — and (b) leaving the gaps overlapping by
-// at least a ship-height, which keeps the threading comfortable.
-function maxCenterDelta(speed: number): number {
-  const reach = SHIP.SPEED * (SPACING / speed); // px the ship can move per wall
-  const overlap = GAP - SHIP.H - 18;
-  return Math.min(0.8 * reach, overlap);
+/** Centre of the safe lane (and of the cave) at a given world x. */
+export function laneCenter(w: World, worldX: number): number {
+  const y =
+    C_MID +
+    C_A1 * Math.sin(worldX / C_L1 + w.p1) +
+    C_A2 * Math.sin(worldX / C_L2 + w.p2);
+  return clamp(y, C_MIN, C_MAX);
+}
+
+/** Half-height of the open passage at a given world x (>= SAFE_HALF always). */
+export function passageHalf(w: World, worldX: number): number {
+  const t1 = 0.5 + 0.5 * Math.sin(worldX / H_L1 + w.p3);
+  const t2 = 0.5 + 0.5 * Math.sin(worldX / H_L2 + w.p4);
+  const m = t1 * 0.65 + t2 * 0.35; // 0..1
+  return HALF_PINCH + (HALF_OPEN - HALF_PINCH) * m;
+}
+
+/** Convenience: the cave's top and bottom wall surfaces at a world x. */
+export function caveBounds(w: World, worldX: number): { top: number; bottom: number } {
+  const c = laneCenter(w, worldX);
+  const h = passageHalf(w, worldX);
+  return { top: c - h, bottom: c + h };
 }
 
 export function createWorld(seed = (Math.random() * 1e9) | 0): World {
+  const rng = mulberry32(seed);
   const w: World = {
     shipY: VIRT.H / 2,
     vy: 0,
     distance: 0,
     speed: SPEED_BASE,
-    walls: [],
     aliens: [],
-    nextWallX: VIRT.W + 120,
-    lastCenter: VIRT.H / 2,
     alienTimer: ALIEN_INTERVAL_START,
     dead: false,
-    rng: mulberry32(seed),
+    rng,
+    p1: rng() * Math.PI * 2,
+    p2: rng() * Math.PI * 2,
+    p3: rng() * Math.PI * 2,
+    p4: rng() * Math.PI * 2,
   };
-  generateAhead(w);
+  // Start the ship on the lane centre at its own x.
+  w.shipY = laneCenter(w, w.distance + SHIP.X);
   return w;
 }
 
-// The safe-corridor centre at any world x: linear interpolation between the
-// surrounding wall centres (flat past either end). Walls' gaps are aligned to
-// this, and aliens are positioned relative to it, so this single curve defines
-// the always-clear path.
-export function corridorCenterAt(w: World, x: number): number {
-  const walls = w.walls;
-  if (walls.length === 0) return VIRT.H / 2;
-  if (x <= walls[0].x) return walls[0].center;
-  for (let i = 0; i < walls.length - 1; i++) {
-    const a = walls[i];
-    const b = walls[i + 1];
-    if (x >= a.x && x <= b.x) {
-      const t = (x - a.x) / (b.x - a.x);
-      return a.center + (b.center - a.center) * t;
-    }
-  }
-  return walls[walls.length - 1].center;
+/** Signed offset (from the lane centre) of an alien, accounting for entry. */
+function alienMagnitude(w: World, a: Alien, worldX: number): number {
+  const rest = ALIEN_OFFSET + Math.sin(a.wobble) * ALIEN_BOB;
+  if (a.entry >= 1) return rest;
+  // Slide in from the wall surface toward its resting offset.
+  const fromWall = passageHalf(w, worldX) - ALIEN_R;
+  const t = 1 - (1 - a.entry) * (1 - a.entry); // ease-out
+  return fromWall + (rest - fromWall) * t;
 }
 
-function generateAhead(w: World) {
-  // Keep walls generated comfortably beyond the right edge.
-  while (w.nextWallX < VIRT.W + SPACING * 2) {
-    const delta = maxCenterDelta(w.speed);
-    const center = clamp(
-      w.lastCenter + (w.rng() * 2 - 1) * delta,
-      CORRIDOR_MIN,
-      CORRIDOR_MAX,
-    );
-    w.walls.push({ x: w.nextWallX, center, scored: false });
-    w.lastCenter = center;
-    w.nextWallX += SPACING;
-  }
+/** Resolved on-screen y of an alien. */
+export function alienY(w: World, a: Alien): number {
+  const worldX = w.distance + a.x;
+  return laneCenter(w, worldX) + a.side * alienMagnitude(w, a, worldX);
 }
 
 function spawnAlien(w: World) {
-  const spawnX = VIRT.W + ALIEN_R;
-  const center = corridorCenterAt(w, spawnX);
-  // Either side of the band is provably on-screen (see CORRIDOR_MIN/MAX);
-  // pick whichever has more breathing room, with a coin-flip tie-break.
-  const roomAbove = center - ALIEN_OFFSET;
-  const roomBelow = VIRT.H - (center + ALIEN_OFFSET);
-  const above =
-    roomAbove > roomBelow + 1
-      ? true
-      : roomBelow > roomAbove + 1
-        ? false
-        : w.rng() < 0.5;
-  const offset = above ? -ALIEN_OFFSET : ALIEN_OFFSET;
-  w.aliens.push({
-    x: spawnX,
-    offset,
-    entry: 0,
-    fromY: above ? -ALIEN_R : VIRT.H + ALIEN_R,
-    wobble: w.rng() * Math.PI * 2,
-  });
+  const side: 1 | -1 = w.rng() < 0.5 ? -1 : 1;
+  w.aliens.push({ x: VIRT.W + ALIEN_R, side, entry: 0, wobble: w.rng() * Math.PI * 2 });
 }
 
-const easeOut = (t: number) => 1 - (1 - t) * (1 - t);
-
-/** Resolved on-screen y of an alien, accounting for its entry animation. */
-export function alienY(w: World, a: Alien): number {
-  const laneY = corridorCenterAt(w, a.x) + a.offset;
-  if (a.entry >= 1) return laneY + Math.sin(a.wobble) * 6;
-  return a.fromY + (laneY - a.fromY) * easeOut(a.entry);
-}
-
-function rectsOverlap(
-  ax: number,
-  ay: number,
-  aw: number,
-  ah: number,
-  bx: number,
-  by: number,
-  bw: number,
-  bh: number,
-): boolean {
-  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+/** Is point (screen px, py) inside a cave wall (i.e. outside the passage)? */
+function hitsWall(w: World, px: number, py: number): boolean {
+  const { top, bottom } = caveBounds(w, w.distance + px);
+  return py < top || py > bottom;
 }
 
 function checkCollision(w: World): boolean {
-  const sx = SHIP.X - SHIP.W / 2;
-  const sy = w.shipY - SHIP.H / 2;
+  // Look-ahead sampling at the triangle's three points (nose + two tail
+  // corners) — the modern stand-in for the original's pixel-colour look-ahead.
+  if (hitsWall(w, SHIP.X + SHIP.NOSE, w.shipY)) return true;
+  if (hitsWall(w, SHIP.X - SHIP.TAIL, w.shipY - SHIP.HALF_H)) return true;
+  if (hitsWall(w, SHIP.X - SHIP.TAIL, w.shipY + SHIP.HALF_H)) return true;
 
-  for (const wall of w.walls) {
-    if (wall.x + WALL_W < sx || wall.x > sx + SHIP.W) continue;
-    const gapTop = wall.center - GAP / 2;
-    const gapBot = wall.center + GAP / 2;
-    // Hit the top slab or the bottom slab of the wall?
-    if (sy < gapTop || sy + SHIP.H > gapBot) return true;
-  }
-
+  const sx = SHIP.X - SHIP.TAIL;
+  const sy = w.shipY - SHIP.HALF_H;
+  const sw = SHIP.NOSE + SHIP.TAIL;
+  const sh = SHIP.HALF_H * 2;
   for (const a of w.aliens) {
     const ay = alienY(w, a);
-    // Treat the alien as a square for collision; shrink a touch to feel fair.
     const r = ALIEN_R - 3;
-    if (
-      rectsOverlap(sx, sy, SHIP.W, SHIP.H, a.x - r, ay - r, r * 2, r * 2)
-    ) {
+    if (sx < a.x + r && sx + sw > a.x - r && sy < ay + r && sy + sh > ay - r) {
       return true;
     }
   }
@@ -229,70 +200,56 @@ export function updateWorld(w: World, dt: number, input: Input): World {
   if (w.dead) return w;
 
   w.speed = speedAt(w.distance);
-  const dx = w.speed * dt;
-  w.distance += dx;
+  w.distance += w.speed * dt;
 
-  // Scroll the world left.
-  for (const wall of w.walls) wall.x -= dx;
-  for (const a of w.aliens) a.x -= dx;
-  w.nextWallX -= dx;
-
-  // Retire off-screen obstacles, then top up ahead.
-  w.walls = w.walls.filter((wall) => wall.x + WALL_W > -40);
-  w.aliens = w.aliens.filter((a) => a.x + ALIEN_R > -40);
-  generateAhead(w);
-
-  // Aliens: progress entry + idle bob.
+  // Scroll aliens with the cave; retire the ones off the left edge.
   for (const a of w.aliens) {
+    a.x -= w.speed * dt;
     if (a.entry < 1) a.entry = Math.min(1, a.entry + dt / ALIEN_ENTRY);
     a.wobble += dt * 3;
   }
+  w.aliens = w.aliens.filter((a) => a.x > -ALIEN_R - 10);
 
-  // Spawn aliens on a tightening timer.
+  // Spawn on a tightening timer.
   w.alienTimer -= dt;
   if (w.alienTimer <= 0) {
     spawnAlien(w);
-    const interval = Math.max(
+    w.alienTimer = Math.max(
       ALIEN_INTERVAL_MIN,
-      ALIEN_INTERVAL_START - w.distance * (1 / 9000),
+      ALIEN_INTERVAL_START - w.distance / 9000,
     );
-    w.alienTimer = interval;
   }
 
-  // Ship vertical movement (direct velocity — arcade feel, exact reach math).
+  // Ship vertical movement (direct velocity — exact reach math).
   w.vy = (input.down ? 1 : 0) * SHIP.SPEED - (input.up ? 1 : 0) * SHIP.SPEED;
-  w.shipY = clamp(w.shipY + w.vy * dt, SHIP.H / 2, VIRT.H - SHIP.H / 2);
+  w.shipY = clamp(w.shipY + w.vy * dt, SHIP.HALF_H, VIRT.H - SHIP.HALF_H);
 
   if (checkCollision(w)) w.dead = true;
   return w;
 }
 
-/** Score is distance travelled, in tens of px. */
 export function scoreOf(w: World): number {
   return Math.floor(w.distance / 10);
 }
 
-// --- Guarantee check (used by the dev self-test, not the hot loop) --------
-// Confirms a continuous, reachable safe corridor runs through the whole level:
-//   1. every wall's gap is at least a ship tall (the ship fits through it);
-//   2. consecutive gaps overlap by more than a ship height, so the corridor is
-//      continuous and the next gap is always reachable from the current one;
-//   3. no alien ever intrudes into that corridor band.
-// If all hold, the level can never become a no-pass scenario.
+// --- Guarantee check (dev self-test, not the hot loop) --------------------
+// Verifies the always-clear, always-reachable safe lane:
+//   1. the cave never closes in past the lane (passageHalf >= SAFE_HALF);
+//   2. no alien ever intrudes into the lane (inner edge stays clear);
+//   3. the lane centre's max slope is within the ship's climb rate, so the
+//      ship can always keep its nose inside the lane.
+// If all hold, the level can never be a no-pass scenario.
 export function verifyPassable(w: World): boolean {
-  const walls = [...w.walls].sort((a, b) => a.x - b.x);
-  for (let i = 0; i < walls.length; i++) {
-    if (GAP < SHIP.H) return false; // ship must fit the gap
-    if (i > 0) {
-      const dc = Math.abs(walls[i].center - walls[i - 1].center);
-      if (dc > GAP - SHIP.H) return false; // gaps must overlap by a ship height
-    }
+  // 1 & 2 sampled across the on-screen + look-ahead range.
+  for (let x = -40; x <= VIRT.W + 200; x += 6) {
+    if (passageHalf(w, w.distance + x) < SAFE_HALF - 1e-6) return false;
   }
-  for (const a of w.aliens) {
-    const cc = corridorCenterAt(w, a.x);
-    const top = cc + a.offset - ALIEN_R;
-    const bot = cc + a.offset + ALIEN_R;
-    if (bot > cc - GAP / 2 && top < cc + GAP / 2) return false; // intrudes on band
-  }
-  return true;
+  // Aliens rest just outside the lane; their nearest edge (at full bob toward
+  // the lane) must still clear it. This holds for every alien by construction.
+  const alienInnerEdge = ALIEN_OFFSET - ALIEN_BOB - ALIEN_R;
+  if (w.aliens.length > 0 && alienInnerEdge < SAFE_HALF - 1e-6) return false;
+  // 3 — bound the lane-centre slope against the ship's reach at top speed.
+  const maxSlope = C_A1 / C_L1 + C_A2 / C_L2; // d(center)/d(worldX)
+  const reachSlope = SHIP.SPEED / SPEED_MAX; // px climbed per px scrolled
+  return maxSlope <= reachSlope * 0.85;
 }


### PR DESCRIPTION
Reworks **If Then Explosion** to be faithful to the original Turing spaceship game.

## Gameplay
- **Continuous cave walls** that swell toward the centre to pinch the passage, then recede — replacing the old discrete vertical walls. Terrain is analytic (summed sines with seeded phases), so it scrolls forever with no stored wall list.
- **Aliens now squeeze the path**: they sit just outside the safe lane and narrow the visible gap, instead of dropping through open space.
- **Triangle ship** with **look-ahead collision** sampled at its nose and tail corners — a nod to the original's pixel-colour look-ahead logic.

## Look
- Retro **green CRT**: chunky pixel cave walls, phosphor-green palette, triangle ship with a thruster, scanline overlay, subtle drifting flecks.

## Still provably passable
A fixed-height **safe lane** is always clear of walls and aliens, and its centre drifts within the ship's climb rate, so it can always be followed. `verifyPassable` was updated to assert (1) the cave never closes past the lane, (2) aliens never intrude on it, and (3) the lane slope stays within the ship's reach. Stress-tested across **400 seeds × 1500 ticks — 0 no-pass scenarios.**

Copy on the Play card and the `/side-scroller` page updated to describe the cave-flyer.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_