### PR TITLE
Add Swole Mate — a Tamagotchi-style care-'em-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx serve out      # preview the production build locally
 | `/tic-tac-toe`   | Browser rebuild of the old game (vs computer or 2-player)        |
 | `/side-scroller` | **If Then Explosion** — retro side-scroller (the old Turing spaceship game): fly through scrolling gaps, dodge dropping aliens |
 | `/flying-pig`    | **Robo Pig Attack** — a Robot Unicorn Attack-style endless runner with a winged robo-pig (jump / flap / dash) |
+| `/swole-mate`    | **Swole Mate** — a Tamagotchi-style handheld: feed/rest a little guy and grind reps for GAINS without killing him |
 | `/collage`       | Drag-and-drop collage tool (the old Pinprint), with PNG export   |
 
 ## Hosting (the slim path — $0)

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,7 +5,14 @@ export const dynamic = "force-static";
 const BASE = "https://adamklockars.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const routes = ["", "/tic-tac-toe", "/collage", "/side-scroller", "/flying-pig"];
+  const routes = [
+    "",
+    "/tic-tac-toe",
+    "/collage",
+    "/side-scroller",
+    "/flying-pig",
+    "/swole-mate",
+  ];
   return routes.map((path) => ({
     url: `${BASE}${path}`,
     lastModified: new Date(),

--- a/app/swole-mate/page.tsx
+++ b/app/swole-mate/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import DemoNav from "@/components/DemoNav";
+import Tamagotchi from "@/components/tamagotchi/Tamagotchi";
+
+export const metadata: Metadata = {
+  title: "Swole Mate — Adam Klockars",
+  description:
+    "A Tamagotchi-style handheld: keep a little guy alive by feeding and resting him, and grow his GAINS by working out — without starving him or letting him collapse from over-training.",
+};
+
+export default function SwoleMatePage() {
+  return (
+    <>
+      <DemoNav />
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-6 py-16">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
+          Play
+        </p>
+        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight sm:text-5xl">
+          Swole Mate
+        </h1>
+        <p className="mt-3 max-w-md text-center text-muted">
+          A handheld care-’em-up in the spirit of the old virtual pets. Feed him,
+          rest him, and grind out reps for GAINS — just don’t let him starve or
+          collapse from over-training. He keeps living while you’re away.
+        </p>
+
+        <div className="mt-12 w-full">
+          <Tamagotchi />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
-import { ArrowUpRight, Grid3x3, Images, Rocket, PiggyBank } from "lucide-react";
+import {
+  ArrowUpRight,
+  Grid3x3,
+  Images,
+  Rocket,
+  PiggyBank,
+  Dumbbell,
+} from "lucide-react";
 import { Reveal } from "@/components/ui/Reveal";
 
 const experiments = [
@@ -28,6 +35,14 @@ const experiments = [
     accent: "#ff5db1",
   },
   {
+    href: "/swole-mate",
+    title: "Swole Mate",
+    blurb:
+      "A Tamagotchi-style handheld: keep a little guy fed and rested while grinding out reps for GAINS. Click a lot, watch the number climb, and don’t let him starve or collapse from over-training.",
+    icon: Dumbbell,
+    accent: "#f472b6",
+  },
+  {
     href: "/collage",
     title: "Collage Studio",
     blurb:
@@ -50,7 +65,7 @@ export default function PlaySection() {
           </h2>
           <p className="mt-4 max-w-xl text-muted">
             Tic-Tac-Toe and the collage tool are rebuilt from the original 2012
-            Django version of this site. The two games are newer — built from
+            Django version of this site. The games are newer — built from
             scratch, inspired by projects and games from past experiences. They
             all run entirely in your browser.
           </p>

--- a/components/tamagotchi/Tamagotchi.tsx
+++ b/components/tamagotchi/Tamagotchi.tsx
@@ -1,0 +1,588 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Drumstick, Dumbbell, Moon, RotateCcw } from "lucide-react";
+import {
+  MAX,
+  type Pet,
+  type Cause,
+  createPet,
+  tickLive,
+  feed,
+  train,
+  toggleRest,
+  applyAway,
+  rank,
+  status,
+  formatAge,
+} from "@/lib/tamagotchi";
+
+const SAVE_KEY = "swolemate-save";
+const REC_KEY = "swolemate-record";
+
+// Game Boy LCD palette.
+const LCD = {
+  bg: "#9bbc0f",
+  light: "#8bac0f",
+  mid: "#306230",
+  dark: "#0f380f",
+};
+const W = 256; // LCD internal resolution
+const H = 208;
+
+type Anim = { type: "idle" | "eat" | "train"; until: number };
+
+type Saved = Pet & { lastSeen: number };
+
+export default function Tamagotchi() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const petRef = useRef<Pet>(createPet());
+  const animRef = useRef<Anim>({ type: "idle", until: 0 });
+  const rafRef = useRef<number>(0);
+  const lastRef = useRef<number>(0);
+  const hideAtRef = useRef<number>(0);
+  const saveAccumRef = useRef<number>(0);
+
+  // React mirror (canvas shows the live detail; these drive chrome + a11y).
+  const [sleeping, setSleeping] = useState(false);
+  const [alive, setAlive] = useState(true);
+  const [death, setDeath] = useState<{
+    cause: Cause;
+    ageSec: number;
+    strength: number;
+  } | null>(null);
+  const [readout, setReadout] = useState({ hunger: 70, energy: 80, strength: 0 });
+  const [record, setRecord] = useState({ strength: 0, ageSec: 0 });
+
+  const captureDeath = useCallback(() => {
+    const p = petRef.current;
+    setDeath({ cause: p.cause, ageSec: p.ageSec, strength: p.strength });
+  }, []);
+
+  const persist = useCallback(() => {
+    const p = petRef.current;
+    const saved: Saved = { ...p, lastSeen: Date.now() };
+    try {
+      localStorage.setItem(SAVE_KEY, JSON.stringify(saved));
+    } catch {
+      /* ignore quota / private mode */
+    }
+  }, []);
+
+  const bumpRecord = useCallback(() => {
+    const p = petRef.current;
+    setRecord((r) => {
+      const next = {
+        strength: Math.max(r.strength, p.strength),
+        ageSec: Math.max(r.ageSec, p.ageSec),
+      };
+      try {
+        localStorage.setItem(REC_KEY, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  // Load saved pet + record on mount, applying gentle "away" decay.
+  useEffect(() => {
+    try {
+      const rec = localStorage.getItem(REC_KEY);
+      if (rec) setRecord(JSON.parse(rec));
+      const raw = localStorage.getItem(SAVE_KEY);
+      if (raw) {
+        const s = JSON.parse(raw) as Saved;
+        const { lastSeen, ...pet } = s;
+        const away = (Date.now() - (lastSeen || Date.now())) / 1000;
+        petRef.current = applyAway(pet as Pet, away);
+        setSleeping(petRef.current.sleeping);
+        setAlive(petRef.current.alive);
+        if (!petRef.current.alive) captureDeath();
+      }
+    } catch {
+      /* corrupt save — start fresh */
+    }
+  }, [captureDeath]);
+
+  const restart = useCallback(() => {
+    petRef.current = createPet();
+    animRef.current = { type: "idle", until: 0 };
+    setSleeping(false);
+    setAlive(true);
+    setDeath(null);
+    persist();
+  }, [persist]);
+
+  // Actions.
+  const doFeed = useCallback(() => {
+    const p = petRef.current;
+    if (!p.alive || p.sleeping) return;
+    feed(p);
+    animRef.current = { type: "eat", until: performance.now() + 600 };
+    persist();
+  }, [persist]);
+
+  const doTrain = useCallback(() => {
+    const p = petRef.current;
+    if (!p.alive || p.sleeping) return;
+    train(p);
+    animRef.current = { type: "train", until: performance.now() + 500 };
+    if (!p.alive) {
+      setAlive(false);
+      captureDeath();
+      bumpRecord();
+    }
+    persist();
+  }, [persist, bumpRecord, captureDeath]);
+
+  const doRest = useCallback(() => {
+    const p = petRef.current;
+    if (!p.alive) return;
+    toggleRest(p);
+    setSleeping(p.sleeping);
+    persist();
+  }, [persist]);
+
+  // Keyboard shortcuts: F feed, T/Space train, R rest.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.repeat && e.key !== " ") return;
+      if (e.key === "f" || e.key === "F") doFeed();
+      else if (e.key === "t" || e.key === "T" || e.key === " ") {
+        doTrain();
+        e.preventDefault();
+      } else if (e.key === "r" || e.key === "R") doRest();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [doFeed, doTrain, doRest]);
+
+  // Away handling + save on tab hide/show.
+  useEffect(() => {
+    const onVis = () => {
+      if (document.hidden) {
+        hideAtRef.current = Date.now();
+        persist();
+      } else if (hideAtRef.current) {
+        const away = (Date.now() - hideAtRef.current) / 1000;
+        applyAway(petRef.current, away);
+        setSleeping(petRef.current.sleeping);
+        lastRef.current = 0; // avoid a giant dt on the next frame
+      }
+    };
+    document.addEventListener("visibilitychange", onVis);
+    window.addEventListener("beforeunload", persist);
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      window.removeEventListener("beforeunload", persist);
+    };
+  }, [persist]);
+
+  // Simulation + render loop.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    canvas.width = W;
+    canvas.height = H;
+    ctx.imageSmoothingEnabled = false;
+
+    let readoutAccum = 0;
+
+    const loop = (ts: number) => {
+      rafRef.current = requestAnimationFrame(loop);
+      const last = lastRef.current || ts;
+      const dt = Math.min(0.1, (ts - last) / 1000);
+      lastRef.current = ts;
+
+      const p = petRef.current;
+      const wasAlive = p.alive;
+      if (p.alive && !document.hidden) tickLive(p, dt);
+      if (wasAlive && !p.alive) {
+        setAlive(false);
+        captureDeath();
+        bumpRecord();
+        persist();
+      }
+
+      // Throttle React readout + autosave.
+      readoutAccum += dt;
+      if (readoutAccum >= 0.4) {
+        readoutAccum = 0;
+        setReadout({
+          hunger: Math.round(p.hunger),
+          energy: Math.round(p.energy),
+          strength: p.strength,
+        });
+      }
+      saveAccumRef.current += dt;
+      if (saveAccumRef.current >= 5) {
+        saveAccumRef.current = 0;
+        persist();
+      }
+
+      drawLCD(ctx, p, animRef.current, ts);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [persist, bumpRecord, captureDeath]);
+
+  const r = rank(readout.strength);
+
+  return (
+    <div className="mx-auto w-full max-w-sm">
+      {/* Handheld shell */}
+      <div className="relative rounded-[2rem] border border-pink-300/20 bg-gradient-to-b from-pink-400 to-pink-500 p-5 pb-7 shadow-[0_20px_60px_-20px_rgba(244,114,182,0.6)]">
+        <div className="mb-1 flex items-center justify-between px-1">
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-pink-900/80">
+            Swole&nbsp;Mate
+          </span>
+          <span className="size-2 rounded-full bg-pink-900/30" aria-hidden />
+        </div>
+
+        {/* LCD bezel */}
+        <div className="rounded-2xl bg-[#0f380f] p-3 shadow-inner">
+          <canvas
+            ref={canvasRef}
+            aria-label={`Swole Mate — hunger ${readout.hunger}, energy ${readout.energy}, gains ${readout.strength} (${r.name})`}
+            className="block w-full rounded-md"
+            style={{ imageRendering: "pixelated", aspectRatio: `${W} / ${H}` }}
+          />
+        </div>
+
+        {/* Buttons */}
+        <div className="mt-5 grid grid-cols-3 gap-3">
+          <PadButton
+            label="Feed"
+            sub="F"
+            disabled={!alive || sleeping}
+            onPress={doFeed}
+          >
+            <Drumstick className="size-5" />
+          </PadButton>
+          <PadButton
+            label="Train"
+            sub="T"
+            disabled={!alive || sleeping}
+            onPress={doTrain}
+          >
+            <Dumbbell className="size-5" />
+          </PadButton>
+          <PadButton
+            label={sleeping ? "Wake" : "Rest"}
+            sub="R"
+            disabled={!alive}
+            active={sleeping}
+            onPress={doRest}
+          >
+            <Moon className="size-5" />
+          </PadButton>
+        </div>
+
+        {/* Death overlay */}
+        {!alive && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center rounded-[2rem] bg-black/65 backdrop-blur-sm">
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-pink-300">
+              R.I.P.
+            </p>
+            <p className="mt-2 max-w-[16rem] text-center text-sm text-white/90">
+              {death?.cause === "hunger"
+                ? "He starved. Feed him more often next time."
+                : "He collapsed from over-training. Let him rest!"}
+            </p>
+            <p className="mt-1 text-xs text-white/60">
+              Reached {rank(death?.strength ?? 0).name} · lived{" "}
+              {formatAge(death?.ageSec ?? 0)}
+            </p>
+            <button
+              onClick={restart}
+              className="mt-5 inline-flex items-center gap-2 rounded-full bg-pink-400 px-6 py-2.5 text-sm font-medium text-pink-950 transition-transform hover:scale-[1.03] active:scale-95"
+            >
+              <RotateCcw className="size-4" />
+              New guy
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Readout chips + record */}
+      <div className="mt-5 grid grid-cols-3 gap-2 text-center font-mono text-xs">
+        <Chip label="Hunger" value={`${readout.hunger}%`} />
+        <Chip label="Energy" value={`${readout.energy}%`} />
+        <Chip label="Gains" value={`${readout.strength}`} />
+      </div>
+      <p className="mt-3 text-center font-mono text-[11px] text-faint">
+        Rank: <span className="text-foreground">{r.name}</span>
+        {record.strength > 0 && (
+          <> · best {record.strength} gains, {formatAge(record.ageSec)} alive</>
+        )}
+      </p>
+      <p className="mt-2 text-center font-mono text-[11px] text-faint">
+        Feed him, train for gains, rest before he drops. Keys: F / T / R.
+      </p>
+    </div>
+  );
+}
+
+function PadButton({
+  label,
+  sub,
+  children,
+  onPress,
+  disabled,
+  active,
+}: {
+  label: string;
+  sub: string;
+  children: React.ReactNode;
+  onPress: () => void;
+  disabled?: boolean;
+  active?: boolean;
+}) {
+  return (
+    <button
+      onPointerDown={(e) => {
+        e.preventDefault();
+        if (!disabled) onPress();
+      }}
+      disabled={disabled}
+      aria-label={`${label} (${sub})`}
+      className={`flex flex-col items-center gap-1 rounded-xl border px-2 py-3 text-[11px] font-bold uppercase tracking-wide transition-all active:translate-y-0.5 active:shadow-none ${
+        active
+          ? "border-pink-900/30 bg-pink-200 text-pink-900 shadow-[0_3px_0_rgba(0,0,0,0.25)]"
+          : "border-pink-900/20 bg-pink-50 text-pink-900 shadow-[0_3px_0_rgba(0,0,0,0.25)]"
+      } ${disabled ? "cursor-not-allowed opacity-40 shadow-none" : "hover:bg-white"}`}
+    >
+      {children}
+      {label}
+    </button>
+  );
+}
+
+function Chip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface px-2 py-2">
+      <div className="text-[9px] uppercase tracking-widest text-faint">{label}</div>
+      <div className="mt-0.5 text-sm font-semibold text-foreground">{value}</div>
+    </div>
+  );
+}
+
+// --------------------------------------------------------------------------
+// LCD rendering (Game Boy palette, chunky pixels)
+// --------------------------------------------------------------------------
+function px(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  c: string,
+) {
+  ctx.fillStyle = c;
+  ctx.fillRect(x, y, w, h);
+}
+
+function drawLCD(
+  ctx: CanvasRenderingContext2D,
+  p: Pet,
+  anim: Anim,
+  ts: number,
+) {
+  px(ctx, 0, 0, W, H, LCD.bg);
+
+  // Stat bars (top).
+  drawBar(ctx, 14, 14, "HUNGER", p.hunger);
+  drawBar(ctx, 14, 34, "ENERGY", p.energy);
+
+  // Rank + age (top-right).
+  const rk = rank(p.strength);
+  text(ctx, `Lv${rk.level} ${rk.name}`, W - 14, 14, LCD.dark, "right");
+  text(ctx, `AGE ${formatAge(p.ageSec)}`, W - 14, 26, LCD.mid, "right");
+  text(ctx, `GAINS ${p.strength}`, W - 14, 38, LCD.dark, "right");
+
+  // Ground line.
+  px(ctx, 0, 168, W, 3, LCD.mid);
+
+  // The guy.
+  const now = ts;
+  const blink = Math.floor(now / 1700) % 10 === 0;
+  const frame = Math.floor(now / 180) % 2;
+  let pose: Anim["type"] | "sleep" | "dead" = "idle";
+  if (!p.alive) pose = "dead";
+  else if (p.sleeping) pose = "sleep";
+  else if (anim.until > now) pose = anim.type;
+  drawGuy(ctx, 128, 168, pose, frame, blink, rk.level);
+
+  // Status line (bottom).
+  text(ctx, status(p), 128, 192, LCD.dark, "center");
+}
+
+function drawBar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  label: string,
+  value: number,
+) {
+  text(ctx, label, x, y + 2, LCD.dark, "left");
+  const bx = x + 56;
+  const bw = 110;
+  // Track.
+  px(ctx, bx - 1, y - 2, bw + 2, 10, LCD.dark);
+  px(ctx, bx, y - 1, bw, 8, LCD.light);
+  // Fill (segmented).
+  const fill = Math.round((Math.max(0, Math.min(MAX, value)) / MAX) * bw);
+  const low = value < 25;
+  for (let i = 0; i < fill; i += 6) {
+    px(ctx, bx + i, y - 1, 5, 8, low ? LCD.mid : LCD.dark);
+  }
+}
+
+// Minimal 3x5 pixel font for the LCD labels/numbers.
+const FONT: Record<string, number[]> = {
+  A: [0b111, 0b101, 0b111, 0b101, 0b101],
+  B: [0b110, 0b101, 0b110, 0b101, 0b110],
+  C: [0b111, 0b100, 0b100, 0b100, 0b111],
+  D: [0b110, 0b101, 0b101, 0b101, 0b110],
+  E: [0b111, 0b100, 0b110, 0b100, 0b111],
+  F: [0b111, 0b100, 0b110, 0b100, 0b100],
+  G: [0b111, 0b100, 0b101, 0b101, 0b111],
+  H: [0b101, 0b101, 0b111, 0b101, 0b101],
+  I: [0b111, 0b010, 0b010, 0b010, 0b111],
+  J: [0b001, 0b001, 0b001, 0b101, 0b111],
+  K: [0b101, 0b101, 0b110, 0b101, 0b101],
+  L: [0b100, 0b100, 0b100, 0b100, 0b111],
+  M: [0b101, 0b111, 0b111, 0b101, 0b101],
+  N: [0b101, 0b111, 0b111, 0b111, 0b101],
+  O: [0b111, 0b101, 0b101, 0b101, 0b111],
+  P: [0b111, 0b101, 0b111, 0b100, 0b100],
+  Q: [0b111, 0b101, 0b101, 0b111, 0b011],
+  R: [0b111, 0b101, 0b110, 0b101, 0b101],
+  S: [0b111, 0b100, 0b111, 0b001, 0b111],
+  T: [0b111, 0b010, 0b010, 0b010, 0b010],
+  U: [0b101, 0b101, 0b101, 0b101, 0b111],
+  V: [0b101, 0b101, 0b101, 0b101, 0b010],
+  W: [0b101, 0b101, 0b111, 0b111, 0b101],
+  X: [0b101, 0b101, 0b010, 0b101, 0b101],
+  Y: [0b101, 0b101, 0b010, 0b010, 0b010],
+  Z: [0b111, 0b001, 0b010, 0b100, 0b111],
+  "0": [0b111, 0b101, 0b101, 0b101, 0b111],
+  "1": [0b010, 0b110, 0b010, 0b010, 0b111],
+  "2": [0b111, 0b001, 0b111, 0b100, 0b111],
+  "3": [0b111, 0b001, 0b111, 0b001, 0b111],
+  "4": [0b101, 0b101, 0b111, 0b001, 0b001],
+  "5": [0b111, 0b100, 0b111, 0b001, 0b111],
+  "6": [0b111, 0b100, 0b111, 0b101, 0b111],
+  "7": [0b111, 0b001, 0b010, 0b010, 0b010],
+  "8": [0b111, 0b101, 0b111, 0b101, 0b111],
+  "9": [0b111, 0b101, 0b111, 0b001, 0b111],
+  "!": [0b010, 0b010, 0b010, 0b000, 0b010],
+  "…": [0b000, 0b000, 0b000, 0b000, 0b101],
+  "·": [0b000, 0b000, 0b010, 0b000, 0b000],
+  " ": [0, 0, 0, 0, 0],
+};
+
+function text(
+  ctx: CanvasRenderingContext2D,
+  str: string,
+  x: number,
+  y: number,
+  color: string,
+  align: "left" | "center" | "right" = "left",
+) {
+  const up = str.toUpperCase();
+  const cw = 4; // 3px glyph + 1 spacing
+  const width = up.length * cw;
+  let sx = align === "left" ? x : align === "center" ? x - width / 2 : x - width;
+  for (const ch of up) {
+    const glyph = FONT[ch] ?? FONT[" "];
+    for (let row = 0; row < 5; row++) {
+      const bits = glyph[row];
+      for (let col = 0; col < 3; col++) {
+        if (bits & (1 << (2 - col))) px(ctx, sx + col, y + row, 1, 1, color);
+      }
+    }
+    sx += cw;
+  }
+}
+
+// The guy, built from chunky blocks. `b` is the pixel size; he grows a little
+// brawnier as his rank climbs.
+function drawGuy(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  baseY: number,
+  pose: Anim["type"] | "sleep" | "dead",
+  frame: number,
+  blink: boolean,
+  level: number,
+) {
+  const b = 5; // block size
+  const D = LCD.dark;
+  const M = LCD.mid;
+  const brawn = Math.min(3, level) * b; // extra shoulder/arm width with rank
+
+  if (pose === "sleep" || pose === "dead") {
+    // Lying down: head left, body right, on the ground line.
+    const y = baseY - 2 * b;
+    px(ctx, cx - 5 * b, y, 4 * b, 3 * b, D); // head
+    px(ctx, cx - b, y, 6 * b, 3 * b, M); // body
+    if (pose === "dead") {
+      // X eyes.
+      px(ctx, cx - 4 * b, y + b, b, b, LCD.bg);
+      px(ctx, cx - 2 * b, y + b, b, b, LCD.bg);
+      // little halo
+      px(ctx, cx - 4 * b, y - 2 * b, 3 * b, b, D);
+    } else {
+      // closed eye + Zzz drifting up.
+      px(ctx, cx - 3 * b, y + b, 2 * b, 1, LCD.bg);
+      const zf = (frame + Math.floor(performance.now() / 400)) % 3;
+      text(ctx, "Z", cx + 5 * b, y - 2 * b - zf * b, D);
+    }
+    return;
+  }
+
+  const headY = baseY - 9 * b;
+  const bodyY = baseY - 6 * b;
+  const legY = baseY - 2 * b;
+
+  // Legs.
+  px(ctx, cx - 2 * b, legY, b, 2 * b, D);
+  px(ctx, cx + b, legY, b, 2 * b, D);
+  // Body (widens with brawn).
+  px(ctx, cx - 2 * b - brawn / 2, bodyY, 4 * b + brawn, 4 * b, M);
+  // Head.
+  px(ctx, cx - 2 * b, headY, 4 * b, 3 * b, D);
+  // Eyes.
+  if (!blink) {
+    px(ctx, cx - b, headY + b, b, b, LCD.bg);
+    px(ctx, cx, headY + b, b, b, LCD.bg);
+  } else {
+    px(ctx, cx - b, headY + 1.5 * b, 2 * b, 1, LCD.bg);
+  }
+
+  if (pose === "train") {
+    // Barbell overhead; alternate frame lowers it to the shoulders.
+    const barY = frame === 0 ? headY - 2 * b : headY;
+    // arms up
+    px(ctx, cx - 3 * b - brawn / 2, bodyY - b, b, 2 * b, D);
+    px(ctx, cx + 2 * b + brawn / 2, bodyY - b, b, 2 * b, D);
+    px(ctx, cx - 6 * b, barY, 12 * b, b, D); // bar
+    px(ctx, cx - 6 * b, barY - b, 2 * b, 3 * b, M); // left plate
+    px(ctx, cx + 4 * b, barY - b, 2 * b, 3 * b, M); // right plate
+  } else if (pose === "eat") {
+    // Arms forward holding a drumstick to the mouth (chew on alt frame).
+    px(ctx, cx + 2 * b + brawn / 2, bodyY, 2 * b, b, D); // arm
+    const fy = frame === 0 ? headY + 2 * b : headY + 1.5 * b;
+    px(ctx, cx + 3 * b, fy, b, b, M); // meat
+    px(ctx, cx + 4 * b, fy - b, b, 2 * b, D); // bone
+  } else {
+    // Idle: arms at sides, slight bob handled by caller timing.
+    px(ctx, cx - 3 * b - brawn / 2, bodyY, b, 3 * b, D);
+    px(ctx, cx + 2 * b + brawn / 2, bodyY, b, 3 * b, D);
+  }
+}

--- a/lib/tamagotchi.ts
+++ b/lib/tamagotchi.ts
@@ -1,0 +1,172 @@
+// Game logic for "Swole Mate" — a Tamagotchi-style handheld pet. You keep a
+// little guy alive by feeding him and letting him rest, and you grow his GAINS
+// by making him work out. Lots of button-clicking, lots of time, no real
+// reward beyond a bigger number and a pet that hasn't died of hunger or
+// collapsed from over-training.
+//
+// Two ways to die, exactly as the old handheld had it:
+//   - HUNGER: neglect feeding and he starves (after a short grace period).
+//   - EXHAUSTION: work out with no energy left and he collapses.
+// Energy only comes back from resting (and a little from food), so the loop is
+// train → tire out → eat & sleep → train again.
+
+export const MAX = 100;
+
+export type Cause = "hunger" | "exhaustion" | null;
+
+export type Pet = {
+  hunger: number; // 0 (empty) .. 100 (full)
+  energy: number; // 0 (spent) .. 100 (rested)
+  strength: number; // "GAINS" — the number that only ever goes up
+  ageSec: number; // total time alive
+  sleeping: boolean;
+  alive: boolean;
+  cause: Cause;
+  starveTimer: number; // seconds spent at zero hunger
+};
+
+// Live (tab-open) rates, per second.
+const HUNGER_DECAY_AWAKE = 0.25;
+const HUNGER_DECAY_SLEEP = 0.15;
+const ENERGY_DRAIN_AWAKE = 0.08; // being awake slowly tires him
+const ENERGY_REGEN_SLEEP = 9; // sleeping recovers energy fast
+const STARVE_GRACE = 15; // seconds at 0 hunger before he starves
+
+// Action effects.
+export const FEED_HUNGER = 18;
+export const FEED_ENERGY = 3;
+export const TRAIN_ENERGY = 12;
+export const TRAIN_HUNGER = 6;
+export const TRAIN_GAIN = 1;
+
+export function createPet(): Pet {
+  return {
+    hunger: 70,
+    energy: 80,
+    strength: 0,
+    ageSec: 0,
+    sleeping: false,
+    alive: true,
+    cause: null,
+    starveTimer: 0,
+  };
+}
+
+/** Advance the pet by `dt` seconds of live (tab-open) time. Mutates + returns. */
+export function tickLive(p: Pet, dt: number): Pet {
+  if (!p.alive) return p;
+
+  p.ageSec += dt;
+
+  p.hunger = Math.max(
+    0,
+    p.hunger - (p.sleeping ? HUNGER_DECAY_SLEEP : HUNGER_DECAY_AWAKE) * dt,
+  );
+
+  if (p.sleeping) {
+    p.energy = Math.min(MAX, p.energy + ENERGY_REGEN_SLEEP * dt);
+  } else {
+    // Awake: energy only trickles down (it comes back from resting/food).
+    p.energy = Math.max(0, p.energy - ENERGY_DRAIN_AWAKE * dt);
+  }
+
+  // Starvation: a short grace at empty, then he's gone.
+  if (p.hunger <= 0) {
+    p.starveTimer += dt;
+    if (p.starveTimer >= STARVE_GRACE) {
+      p.alive = false;
+      p.cause = "hunger";
+    }
+  } else {
+    p.starveTimer = 0;
+  }
+
+  return p;
+}
+
+/** Feed him. No-op while asleep or dead. */
+export function feed(p: Pet): Pet {
+  if (!p.alive || p.sleeping) return p;
+  p.hunger = Math.min(MAX, p.hunger + FEED_HUNGER);
+  p.energy = Math.min(MAX, p.energy + FEED_ENERGY);
+  return p;
+}
+
+/** One workout rep. Grows GAINS but burns energy — and at zero energy, a rep
+ *  is the rep that kills him (collapse from over-training). */
+export function train(p: Pet): Pet {
+  if (!p.alive || p.sleeping) return p;
+  if (p.energy <= 0) {
+    p.alive = false;
+    p.cause = "exhaustion";
+    return p;
+  }
+  p.strength += TRAIN_GAIN;
+  p.energy = Math.max(0, p.energy - TRAIN_ENERGY);
+  p.hunger = Math.max(0, p.hunger - TRAIN_HUNGER);
+  return p;
+}
+
+/** Toggle sleep (the only way to recover energy quickly). */
+export function toggleRest(p: Pet): Pet {
+  if (!p.alive) return p;
+  p.sleeping = !p.sleeping;
+  return p;
+}
+
+// Away (tab-closed) time is gentle and never fatal: he gets very hungry but
+// won't die while you're gone — and he rests up a little. Death only happens
+// during live play, so a casual visitor never returns to a corpse.
+export function applyAway(p: Pet, seconds: number): Pet {
+  if (!p.alive) return p;
+  const s = Math.min(Math.max(0, seconds), 86400); // cap at a day
+  p.ageSec += s;
+  p.hunger = Math.max(8, p.hunger - s * 0.05);
+  p.energy = Math.min(70, p.energy + s * 0.2);
+  p.starveTimer = 0;
+  p.sleeping = false;
+  return p;
+}
+
+// --- Flavor helpers -------------------------------------------------------
+
+const RANKS: { at: number; name: string }[] = [
+  { at: 0, name: "Couch Potato" },
+  { at: 10, name: "Rookie" },
+  { at: 25, name: "Fit" },
+  { at: 50, name: "Buff" },
+  { at: 100, name: "Swole" },
+  { at: 200, name: "Beast" },
+  { at: 350, name: "Hercules" },
+  { at: 600, name: "Legend" },
+];
+
+export function rank(strength: number): { name: string; level: number } {
+  let level = 0;
+  for (let i = 0; i < RANKS.length; i++) {
+    if (strength >= RANKS[i].at) level = i;
+  }
+  return { name: RANKS[level].name, level };
+}
+
+/** Short status line for the LCD. */
+export function status(p: Pet): string {
+  if (!p.alive) {
+    return p.cause === "hunger" ? "Starved…" : "Collapsed…";
+  }
+  if (p.sleeping) return "Zzz…";
+  if (p.hunger <= 0) return "STARVING!";
+  if (p.energy <= 0) return "Exhausted!";
+  if (p.hunger < 25) return "Hungry…";
+  if (p.energy < 25) return "Tired…";
+  if (p.strength > 0 && p.strength % 25 === 0) return "GAINS!";
+  return "Feelin' good!";
+}
+
+export function formatAge(sec: number): string {
+  const s = Math.floor(sec);
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+  return `${Math.floor(s / 86400)}d ${Math.floor((s % 86400) / 3600)}h`;
+}


### PR DESCRIPTION
Adds **Swole Mate** at `/swole-mate` — a Tamagotchi-style handheld care-'em-up.

## The loop
Keep a little guy alive and grow his **GAINS**:
- **Feed** (hunger), **Rest**/sleep (energy), **Train** (strength).
- Energy only comes back from resting (and a little from food), so it's train → tire out → eat & sleep → train again. Lots of clicking, lots of time, no reward beyond a bigger number and a pet that's still breathing.

## Two ways to die (like the old handhelds)
- **Starvation** — neglect feeding and he starves after a short grace.
- **Exhaustion** — work out at zero energy and he collapses.

## Details
- Persists to `localStorage` and keeps "living" while you're away — but offline is gentle and **never fatal** (death only happens during live play), so a casual visitor never returns to a corpse. Tracks best-gains / longest-life records.
- Pure logic in `lib/tamagotchi.ts`; the component renders a Game Boy-palette LCD (chunky 3×5 pixel font, a sprite with idle/eat/train/sleep/dead poses that gets brawnier as his rank climbs) plus Feed/Train/Rest buttons (keys F / T / R).
- Wired into the Play section, sitemap, and README. Build + typecheck pass.

Note: I picked the name **Swole Mate** (pun on soulmate) — happy to rename if you'd prefer something else.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_