### PR TITLE
Fix games crammed on mobile

### DIFF
--- a/app/flying-pig/page.tsx
+++ b/app/flying-pig/page.tsx
@@ -12,19 +12,19 @@ export default function FlyingPigPage() {
   return (
     <>
       <DemoNav />
-      <main className="mx-auto flex max-w-5xl flex-col items-center px-6 py-16">
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-4 py-8 sm:px-6 sm:py-16">
         <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
           Play
         </p>
-        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight sm:text-5xl">
+        <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
           Robo Pig Attack
         </h1>
-        <p className="mt-3 max-w-md text-center text-muted">
+        <p className="mt-3 hidden max-w-md text-center text-muted sm:block">
           A loving riff on Robot Unicorn Attack — only here the galloping
           unicorn is a winged robo-pig. Hold onto your dreams and run forever.
         </p>
 
-        <div className="mt-12 w-full">
+        <div className="mt-6 w-full sm:mt-12">
           <FlyingPig />
         </div>
       </main>

--- a/app/side-scroller/page.tsx
+++ b/app/side-scroller/page.tsx
@@ -12,19 +12,19 @@ export default function SideScrollerPage() {
   return (
     <>
       <DemoNav />
-      <main className="mx-auto flex max-w-5xl flex-col items-center px-6 py-16">
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-4 py-8 sm:px-6 sm:py-16">
         <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
           Play
         </p>
-        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight sm:text-5xl">
+        <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
           If Then Explosion
         </h1>
-        <p className="mt-3 max-w-md text-center text-muted">
+        <p className="mt-3 hidden max-w-md text-center text-muted sm:block">
           A retro green cave-flyer, rebuilt from the triangle-ship game I first
           wrote in Turing. Thread the pinching cave, dodge the aliens.
         </p>
 
-        <div className="mt-12 w-full">
+        <div className="mt-6 w-full sm:mt-12">
           <SideScroller />
         </div>
       </main>

--- a/app/swole-mate/page.tsx
+++ b/app/swole-mate/page.tsx
@@ -12,20 +12,20 @@ export default function SwoleMatePage() {
   return (
     <>
       <DemoNav />
-      <main className="mx-auto flex max-w-5xl flex-col items-center px-6 py-16">
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-4 py-8 sm:px-6 sm:py-16">
         <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
           Play
         </p>
-        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight sm:text-5xl">
+        <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
           Swole Mate
         </h1>
-        <p className="mt-3 max-w-md text-center text-muted">
+        <p className="mt-3 max-w-md text-center text-sm text-muted sm:text-base">
           A handheld care-’em-up in the spirit of the old virtual pets. Feed him,
           rest him, and grind out reps for GAINS — just don’t let him starve or
           collapse from over-training. He keeps living while you’re away.
         </p>
 
-        <div className="mt-12 w-full">
+        <div className="mt-8 w-full sm:mt-12">
           <Tamagotchi />
         </div>
       </main>

--- a/app/tic-tac-toe/page.tsx
+++ b/app/tic-tac-toe/page.tsx
@@ -12,18 +12,18 @@ export default function TicTacToePage() {
   return (
     <>
       <DemoNav />
-      <main className="mx-auto flex max-w-5xl flex-col items-center px-6 py-16">
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-4 py-8 sm:px-6 sm:py-16">
         <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
           Play
         </p>
-        <h1 className="mt-3 font-display text-4xl font-bold tracking-tight sm:text-5xl">
+        <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
           Tic-Tac-Toe
         </h1>
         <p className="mt-3 max-w-md text-center text-muted">
           The old server-rendered game, rebuilt to run instantly in your browser.
         </p>
 
-        <div className="mt-12 w-full max-w-sm">
+        <div className="mt-8 w-full max-w-sm sm:mt-12">
           <TicTacToe />
         </div>
       </main>

--- a/components/flyingpig/FlyingPig.tsx
+++ b/components/flyingpig/FlyingPig.tsx
@@ -186,16 +186,16 @@ export default function FlyingPig() {
         )}
 
         {phase !== "playing" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/55 backdrop-blur-sm">
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center bg-black/55 backdrop-blur-sm">
             {phase === "menu" ? (
               <>
-                <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-accent sm:text-xs">
                   Endless runner
                 </p>
-                <h2 className="mt-2 font-display text-3xl font-bold sm:text-4xl">
+                <h2 className="mt-1 font-display text-2xl font-bold sm:mt-2 sm:text-4xl">
                   Robo Pig Attack
                 </h2>
-                <p className="mt-3 max-w-sm text-center text-sm text-muted">
+                <p className="mt-2 max-w-sm text-xs leading-snug text-muted sm:text-sm">
                   A winged robo-pig runs forever. Jump the gaps, flap to
                   double-jump, and dash to smash the crystals. How far can you
                   fly?
@@ -203,16 +203,16 @@ export default function FlyingPig() {
               </>
             ) : (
               <>
-                <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-accent sm:text-xs">
                   The dream ends
                 </p>
-                <h2 className="mt-2 font-display text-3xl font-bold sm:text-4xl">
+                <h2 className="mt-1 font-display text-2xl font-bold sm:mt-2 sm:text-4xl">
                   {score} <span className="text-muted">m</span>
                 </h2>
                 {score >= best && score > 0 ? (
                   <p className="mt-1 text-sm text-accent">New best! 🐷✨</p>
                 ) : (
-                  <p className="mt-2 max-w-xs text-center text-sm italic text-muted">
+                  <p className="mt-2 max-w-xs text-xs italic leading-snug text-muted sm:text-sm">
                     “{deathLine}”
                   </p>
                 )}
@@ -220,7 +220,7 @@ export default function FlyingPig() {
             )}
             <button
               onClick={start}
-              className="mt-6 inline-flex items-center gap-2 rounded-full bg-accent px-7 py-3 font-medium text-background transition-transform hover:scale-[1.03] active:scale-95"
+              className="mt-4 inline-flex items-center gap-2 rounded-full bg-accent px-6 py-2.5 font-medium text-background transition-transform hover:scale-[1.03] active:scale-95 sm:mt-6 sm:px-7 sm:py-3"
             >
               {phase === "menu" ? (
                 <Play className="size-4" />

--- a/components/sidescroller/SideScroller.tsx
+++ b/components/sidescroller/SideScroller.tsx
@@ -198,26 +198,29 @@ export default function SideScroller() {
         <canvas ref={canvasRef} className="block h-full w-full" />
 
         {phase !== "playing" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/65 backdrop-blur-sm">
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center bg-black/65 backdrop-blur-sm">
             {phase === "menu" ? (
               <>
                 <p
-                  className="font-mono text-xs uppercase tracking-[0.3em]"
+                  className="font-mono text-[10px] uppercase tracking-[0.3em] sm:text-xs"
                   style={{ color: GREEN }}
                 >
                   Retro · Turing
                 </p>
                 <h2
-                  className="mt-2 font-display text-3xl font-bold sm:text-4xl"
+                  className="mt-1 font-display text-2xl font-bold sm:mt-2 sm:text-4xl"
                   style={{ color: GREEN }}
                 >
                   If Then Explosion
                 </h2>
-                <p className="mt-3 max-w-xs text-center text-sm text-muted">
-                  Fly the triangle through the cave. The walls close toward the
-                  centre and aliens squeeze the gap — but there&apos;s always a
-                  way through. Up / Down arrows (or W / S); on touch, hold the
-                  top or bottom.
+                <p className="mt-2 max-w-xs text-xs leading-snug text-muted sm:text-sm">
+                  Fly the triangle through the cave — walls pinch toward the
+                  centre and aliens squeeze the gap, but there&apos;s always a
+                  way through.{" "}
+                  <span className="hidden sm:inline">
+                    Up / Down arrows (or W / S); on touch, hold the top or
+                    bottom.
+                  </span>
                 </p>
               </>
             ) : (
@@ -229,7 +232,7 @@ export default function SideScroller() {
                   Boom
                 </p>
                 <h2
-                  className="mt-2 font-display text-3xl font-bold sm:text-4xl"
+                  className="mt-1 font-display text-2xl font-bold sm:mt-2 sm:text-4xl"
                   style={{ color: GREEN }}
                 >
                   {score} <span className="text-muted">pts</span>
@@ -243,7 +246,7 @@ export default function SideScroller() {
             )}
             <button
               onClick={start}
-              className="mt-6 inline-flex items-center gap-2 rounded-full px-7 py-3 font-medium text-black transition-transform hover:scale-[1.03] active:scale-95"
+              className="mt-4 inline-flex items-center gap-2 rounded-full px-6 py-2.5 font-medium text-black transition-transform hover:scale-[1.03] active:scale-95 sm:mt-6 sm:px-7 sm:py-3"
               style={{ background: GREEN }}
             >
               {phase === "menu" ? (


### PR DESCRIPTION
Fixes the cramped game pages on mobile (reported with screenshots of If Then Explosion and Robo Pig Attack).

**Problem:** a large page title + description stacked above a short 16:9 canvas, and the in-game menu overlays used desktop-sized text — jamming the Start button against the touch controls.

**Changes:**
- **Game pages** (`/side-scroller`, `/flying-pig`, `/swole-mate`, `/tic-tac-toe`): smaller top padding and heading on mobile, tighter margin above the game, and the redundant page description is hidden on phones for the two arcade games (their in-game menu already introduces them).
- **Menu / game-over overlays** (If Then Explosion, Robo Pig Attack): smaller heading + body text on mobile, tighter spacing, centered with horizontal padding, and a compact Start button so it always fits the short canvas. Full controls hint shows on `sm+`.

Desktop layout is unchanged (`sm:` restores the original sizes).

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_