### PR TITLE
Rename Bootleg Baron → Get Mitch Quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npx serve out      # preview the production build locally
 | `/side-scroller` | **If Then Explosion** — retro side-scroller (the old Turing spaceship game): fly through scrolling gaps, dodge dropping aliens |
 | `/flying-pig`    | **Robo Pig Attack** — a Robot Unicorn Attack-style endless runner with a winged robo-pig (jump / flap / dash) |
 | `/swole-mate`    | **Swole Mate** — a Tamagotchi-style handheld: feed/rest a little guy and grind reps for GAINS without killing him |
-| `/bootleg-baron` | **Bootleg Baron** — a parody of the Drug Lord / Drug Wars text trader (buy low / sell high / dodge busts / pay the shark) |
+| `/get-mitch-quick` | **Get Mitch Quick** — a parody of the Drug Lord / Drug Wars text trader (buy low / sell high / dodge busts / pay the shark) |
 | `/collage`       | Drag-and-drop collage tool (the old Pinprint), with PNG export   |
 
 ## Hosting (the slim path — $0)

--- a/app/get-mitch-quick/page.tsx
+++ b/app/get-mitch-quick/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
 import DemoNav from "@/components/DemoNav";
-import BootlegBaron from "@/components/bootlegbaron/BootlegBaron";
+import GetMitchQuick from "@/components/getmitchquick/GetMitchQuick";
 
 export const metadata: Metadata = {
-  title: "Bootleg Baron — Adam Klockars",
+  title: "Get Mitch Quick — Adam Klockars",
   description:
-    "A parody remake of the old DOS text trader Drug Lord / Drug Wars — buy low, sell high on absurd black-market goods, dodge escalating busts, pay off the loan shark, and try to get rich in 30 days.",
+    "A parody remake of the old DOS text trader Drug Lord / Drug Wars — buy low, sell high on absurd black-market goods, dodge escalating busts, pay off the loan shark, and get Mitch quick in 30 days.",
 };
 
-export default function BootlegBaronPage() {
+export default function GetMitchQuickPage() {
   return (
     <>
       <DemoNav />
@@ -17,7 +17,7 @@ export default function BootlegBaronPage() {
           Play
         </p>
         <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
-          Bootleg Baron
+          Get Mitch Quick
         </h1>
         <p className="mt-3 hidden max-w-md text-center text-muted sm:block">
           A parody of the old DOS text trader I wasted study hall on. Buy low,
@@ -26,7 +26,7 @@ export default function BootlegBaronPage() {
         </p>
 
         <div className="mt-6 w-full sm:mt-12">
-          <BootlegBaron />
+          <GetMitchQuick />
         </div>
       </main>
     </>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,7 +12,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/side-scroller",
     "/flying-pig",
     "/swole-mate",
-    "/bootleg-baron",
+    "/get-mitch-quick",
   ];
   return routes.map((path) => ({
     url: `${BASE}${path}`,

--- a/components/getmitchquick/GetMitchQuick.tsx
+++ b/components/getmitchquick/GetMitchQuick.tsx
@@ -25,14 +25,14 @@ import {
   usedSpace,
   spaceLeft,
   netWorth,
-} from "@/lib/bootlegbaron";
+} from "@/lib/getmitchquick";
 
 type Panel = "market" | "travel" | "shop" | "shark";
-const BEST_KEY = "bootlegbaron-best";
+const BEST_KEY = "getmitchquick-best";
 const AMBER = "#ffb000";
 const AMBER_DIM = "#a8741a";
 
-export default function BootlegBaron() {
+export default function GetMitchQuick() {
   const [game, setGame] = useState<Game | null>(null);
   const [panel, setPanel] = useState<Panel>("market");
   const [best, setBest] = useState<number | null>(null);

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -44,10 +44,10 @@ const experiments = [
     accent: "#f472b6",
   },
   {
-    href: "/bootleg-baron",
-    title: "Bootleg Baron",
+    href: "/get-mitch-quick",
+    title: "Get Mitch Quick",
     blurb:
-      "A parody of the old DOS text trader Drug Lord / Drug Wars: buy low and sell high on absurd contraband, dodge escalating busts, pay off the loan shark, and try to get rich before it gets you.",
+      "A parody of the old DOS text trader Drug Lord / Drug Wars: buy low and sell high on absurd contraband, dodge escalating busts, pay off the loan shark, and get Mitch quick before it gets you.",
     icon: Terminal,
     accent: "#ffb000",
   },

--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -1,4 +1,4 @@
-// Game logic for "Bootleg Baron" — a parody remake of the old DOS text trader
+// Game logic for "Get Mitch Quick" — a parody remake of the old DOS text trader
 // Drug Lord / Drug Wars. Same loop: travel between spots, buy low and sell high
 // on wildly swinging prices, dodge (or fight) escalating cop busts, stock up on
 // defensive gear that never quite saves you, and try to pay off the loan shark


### PR DESCRIPTION
Renames **Bootleg Baron → Get Mitch Quick** — a play on "get rich quick" (and on a guy named Mitch), which fits a get-rich-quick hustle game better.

Renames the route (`/bootleg-baron` → `/get-mitch-quick`), the component, the lib module, and all display copy. Gameplay is unchanged. Typecheck + build pass.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_