### PR TITLE
Get Mitch Quick: dollar-sign icon + risky overdraft

### DIFF
--- a/components/getmitchquick/GetMitchQuick.tsx
+++ b/components/getmitchquick/GetMitchQuick.tsx
@@ -25,6 +25,7 @@ import {
   usedSpace,
   spaceLeft,
   netWorth,
+  availableFunds,
 } from "@/lib/getmitchquick";
 
 type Panel = "market" | "travel" | "shop" | "shark";
@@ -93,7 +94,15 @@ export default function GetMitchQuick() {
         {/* Status */}
         <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-b pb-3 text-xs sm:grid-cols-4" style={{ borderColor: "#3a2c10" }}>
           <Stat label="Day" value={`${g.day}/${MAX_DAYS}`} />
-          <Stat label="Cash" value={`$${g.cash.toLocaleString()}`} />
+          <Stat
+            label="Cash"
+            value={
+              g.cash < 0
+                ? `-$${Math.abs(g.cash).toLocaleString()}`
+                : `$${g.cash.toLocaleString()}`
+            }
+            danger={g.cash < 0}
+          />
           <Stat label="Debt" value={`$${g.debt.toLocaleString()}`} danger={g.debt > 0} />
           <Stat label="HP" value={`${g.hp}`} danger={g.hp <= 30} />
           <Stat label="Spot" value={LOCATIONS[g.location]} />
@@ -288,19 +297,19 @@ function Shop({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => void })
       <ShopRow
         label={`Piece (+1 firepower) — fight off busts`}
         price={GUN_PRICE}
-        disabled={g.cash < GUN_PRICE}
+        disabled={availableFunds(g) < GUN_PRICE}
         onClick={() => apply(buyGun)}
       />
       <ShopRow
         label={`Kevlar hoodie (+1 padding) — soak damage`}
         price={ARMOR_PRICE}
-        disabled={g.cash < ARMOR_PRICE}
+        disabled={availableFunds(g) < ARMOR_PRICE}
         onClick={() => apply(buyArmor)}
       />
       <ShopRow
         label={`Patch up (+${PATCH_HP} HP)`}
         price={PATCH_PRICE}
-        disabled={g.cash < PATCH_PRICE || g.hp >= START_HP}
+        disabled={availableFunds(g) < PATCH_PRICE || g.hp >= START_HP}
         onClick={() => apply(patchUp)}
       />
       <p className="pt-1 text-[11px]" style={{ color: AMBER_DIM }}>
@@ -365,7 +374,7 @@ function Encounter({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => vo
         ${p.price} for +1 {p.item === "armor" ? "padding" : "firepower"}
       </p>
       <div className="mt-4 flex gap-3">
-        <ActBtn onClick={() => apply((s) => resolveOffer(s, true))} disabled={g.cash < p.price}>Buy</ActBtn>
+        <ActBtn onClick={() => apply((s) => resolveOffer(s, true))} disabled={availableFunds(g) < p.price}>Buy</ActBtn>
         <ActBtn onClick={() => apply((s) => resolveOffer(s, false))}>Pass</ActBtn>
       </div>
     </div>

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -6,7 +6,7 @@ import {
   Rocket,
   PiggyBank,
   Dumbbell,
-  Terminal,
+  DollarSign,
 } from "lucide-react";
 import { Reveal } from "@/components/ui/Reveal";
 
@@ -47,8 +47,8 @@ const experiments = [
     href: "/get-mitch-quick",
     title: "Get Mitch Quick",
     blurb:
-      "A parody of the old DOS text trader Drug Lord / Drug Wars: buy low and sell high on absurd contraband, dodge escalating busts, pay off the loan shark, and get Mitch quick before it gets you.",
-    icon: Terminal,
+      "A parody of the old DOS text trader Drug Lord / Drug Wars: buy low and sell high, dodge escalating busts, ride the overdraft, pay off the loan shark, and get Mitch quick before it gets you.",
+    icon: DollarSign,
     accent: "#ffb000",
   },
   {

--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -22,6 +22,11 @@ export const ARMOR_PRICE = 280; // +1 padding (soaks damage)
 export const PATCH_HP = 25;
 export const PATCH_PRICE = 200;
 
+// You can spend this far into the red. Handy — but the bank can call the
+// overdraft at any time and seize your stash to settle it.
+export const OVERDRAFT_LIMIT = 2000;
+const OVERDRAFT_CALL_CHANCE = 0.16; // per travel, while you're overdrawn
+
 export type GoodDef = { name: string; min: number; max: number; rare: number };
 
 // Goods with different price ranges; `rare` = chance it's missing today. The
@@ -83,6 +88,8 @@ const pick = <T>(g: Game, arr: T[]): T => arr[Math.floor(rnd(g) * arr.length)];
 // --- helpers --------------------------------------------------------------
 export const usedSpace = (g: Game) => g.coat.reduce((a, b) => a + b, 0);
 export const spaceLeft = (g: Game) => CAPACITY - usedSpace(g);
+/** Spendable money, including the overdraft buffer. */
+export const availableFunds = (g: Game) => g.cash + OVERDRAFT_LIMIT;
 
 /** Value of the duffel at today's prices (avg mid-price when unavailable). */
 export function stashValue(g: Game): number {
@@ -143,6 +150,11 @@ export function newGame(seed = (Math.random() * 1e9) | 0): Game {
   };
   log(g, `Day 1 — you start in ${LOCATIONS[0]} with $${START_CASH} cash and a`);
   log(g, `$${START_DEBT} debt to a loan shark. 30 days. Get rich. Good luck.`);
+  log(
+    g,
+    `Your account has a $${OVERDRAFT_LIMIT} overdraft — spend into the red, but`,
+  );
+  log(g, "the bank can call it and seize your stash at any time.");
   rollMarket(g);
   return g;
 }
@@ -152,7 +164,7 @@ export function buy(state: Game, i: number, qty: number): Game {
   const g = clone(state);
   const price = g.market[i];
   if (g.over || price == null || qty <= 0) return g;
-  const affordable = Math.floor(g.cash / price);
+  const affordable = Math.floor(availableFunds(g) / price);
   const n = Math.min(qty, affordable, spaceLeft(g));
   if (n <= 0) {
     log(g, n === 0 && affordable === 0 ? "You can't afford any." : "No room left in the duffel.");
@@ -179,7 +191,7 @@ export function sell(state: Game, i: number, qty: number): Game {
 // --- shop / shark ---------------------------------------------------------
 export function buyGun(state: Game): Game {
   const g = clone(state);
-  if (g.over || g.cash < GUN_PRICE) return g;
+  if (g.over || availableFunds(g) < GUN_PRICE) return g;
   g.cash -= GUN_PRICE;
   g.guns += 1;
   log(g, `Bought a piece. Firepower is now ${g.guns}.`);
@@ -187,7 +199,7 @@ export function buyGun(state: Game): Game {
 }
 export function buyArmor(state: Game): Game {
   const g = clone(state);
-  if (g.over || g.cash < ARMOR_PRICE) return g;
+  if (g.over || availableFunds(g) < ARMOR_PRICE) return g;
   g.cash -= ARMOR_PRICE;
   g.armor += 1;
   log(g, `Picked up a Kevlar hoodie. Padding is now ${g.armor}.`);
@@ -195,7 +207,7 @@ export function buyArmor(state: Game): Game {
 }
 export function patchUp(state: Game): Game {
   const g = clone(state);
-  if (g.over || g.cash < PATCH_PRICE || g.hp >= START_HP) return g;
+  if (g.over || availableFunds(g) < PATCH_PRICE || g.hp >= START_HP) return g;
   g.cash -= PATCH_PRICE;
   g.hp = Math.min(START_HP, g.hp + PATCH_HP);
   log(g, `Patched up at the clinic. HP is now ${g.hp}.`);
@@ -244,6 +256,21 @@ export function travel(state: Game, loc: number): Game {
 }
 
 function rollEvent(g: Game): Game {
+  // The bank can call your overdraft whenever you're in the red — they seize
+  // the stash to settle up. You could lose it at any time.
+  if (g.cash < 0 && rnd(g) < OVERDRAFT_CALL_CHANCE) {
+    const seized = stashValue(g);
+    g.coat = g.coat.map(() => 0);
+    g.cash += seized; // liquidate the stash against the overdraft
+    log(
+      g,
+      seized > 0
+        ? `🏦 The bank CALLED your overdraft! They seized your whole stash (~$${seized}) to settle up.`
+        : "🏦 The bank CALLED your overdraft! Nothing to seize — they just froze you in the red.",
+    );
+    return g;
+  }
+
   const roll = rnd(g);
   const heat = g.day / MAX_DAYS; // 0..1, rises over time
   // The richer Mitch gets, the more heat he draws — big-time dealers get busted.
@@ -334,7 +361,7 @@ export function resolveOffer(state: Game, accept: boolean): Game {
     g.pending = null;
     return g;
   }
-  if (g.cash < p.price) {
+  if (availableFunds(g) < p.price) {
     log(g, "You're short on cash. They scoff and leave.");
     g.pending = null;
     return g;


### PR DESCRIPTION
Two tweaks to Get Mitch Quick:

1. **Dollar-sign icon** on the Play card (was a terminal icon).
2. **A risky overdraft.** You now have a $2,000 overdraft — you can spend into the red on goods, gear, and street offers, and cash shows in **red** when negative. But true to "you could lose it at any time": while you're overdrawn, the bank can **call the overdraft** on any travel (~16%/day) and **seize your entire stash** to settle the balance. Leveraging up is powerful but can wipe your inventory without warning.

Typecheck + build pass; 300-run smoke test all terminate cleanly.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_