### PR TITLE
Get Mitch Quick: new travel spots

### DIFF
--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -44,12 +44,13 @@ export const GOODS: GoodDef[] = [
 ];
 
 export const LOCATIONS = [
-  "The Cul-de-Sac",
-  "Food Court",
-  "Flea Market",
-  "Strip Mall",
-  "The Marina",
-  "The Docks",
+  "Nuden",
+  "Barefax",
+  "Cuba",
+  "Mexico",
+  "Charlotte",
+  "Vanier",
+  "Casino",
 ];
 
 export type Pending =


### PR DESCRIPTION
Swaps the Get Mitch Quick travel spots to: **Nuden, Barefax, Cuba, Mexico, Charlotte, Vanier, Casino** (now 7 spots; you start in Nuden). Typecheck + build pass.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_