### PR TITLE
Get Mitch Quick: Ottawa nightlife spots + Ottawa shop items

### DIFF
--- a/components/getmitchquick/GetMitchQuick.tsx
+++ b/components/getmitchquick/GetMitchQuick.tsx
@@ -8,8 +8,6 @@ import {
   CAPACITY,
   GUN_PRICE,
   ARMOR_PRICE,
-  PATCH_PRICE,
-  PATCH_HP,
   START_HP,
   type Game,
   newGame,
@@ -17,7 +15,7 @@ import {
   sell,
   buyGun,
   buyArmor,
-  patchUp,
+  buyHeal,
   payShark,
   travel,
   resolveCombat,
@@ -270,7 +268,7 @@ function Travel({ g, apply, done }: { g: Game; apply: (fn: (g: Game) => Game) =>
       <p className="mb-2 text-xs" style={{ color: AMBER_DIM }}>
         Travelling burns a day (and the shark&apos;s interest). Pick a spot:
       </p>
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid max-h-[180px] grid-cols-2 gap-2 overflow-y-auto pr-1">
         {LOCATIONS.map((loc, i) => (
           <button
             key={loc}
@@ -291,9 +289,27 @@ function Travel({ g, apply, done }: { g: Game; apply: (fn: (g: Game) => Game) =>
   );
 }
 
+// Ottawa-stocked shop. Heals are local late-night cures; gear is for busts.
+const HEALS: { name: string; hp: number; price: number }[] = [
+  { name: "Shawarma", hp: 24, price: 45 },
+  { name: "BeaverTail", hp: 12, price: 18 },
+  { name: "Poutine", hp: 18, price: 32 },
+  { name: "Civic ER visit", hp: START_HP, price: 220 },
+];
+
 function Shop({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => void }) {
+  const full = g.hp >= START_HP;
   return (
     <div className="space-y-2 text-xs">
+      {HEALS.map((h) => (
+        <ShopRow
+          key={h.name}
+          label={`${h.name} — ${h.hp >= START_HP ? "full heal" : `+${h.hp} HP`}`}
+          price={h.price}
+          disabled={availableFunds(g) < h.price || full}
+          onClick={() => apply((s) => buyHeal(s, h.hp, h.price, h.name))}
+        />
+      ))}
       <ShopRow
         label={`Piece (+1 firepower) — fight off busts`}
         price={GUN_PRICE}
@@ -301,19 +317,14 @@ function Shop({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => void })
         onClick={() => apply(buyGun)}
       />
       <ShopRow
-        label={`Kevlar hoodie (+1 padding) — soak damage`}
+        label={`Puffer jacket (+1 padding) — soak damage`}
         price={ARMOR_PRICE}
         disabled={availableFunds(g) < ARMOR_PRICE}
         onClick={() => apply(buyArmor)}
       />
-      <ShopRow
-        label={`Patch up (+${PATCH_HP} HP)`}
-        price={PATCH_PRICE}
-        disabled={availableFunds(g) < PATCH_PRICE || g.hp >= START_HP}
-        onClick={() => apply(patchUp)}
-      />
       <p className="pt-1 text-[11px]" style={{ color: AMBER_DIM }}>
-        Stack all the gear you want. It still won&apos;t be enough.
+        {full ? "You're patched up. " : ""}Stack all the gear you want. It still
+        won&apos;t be enough.
       </p>
     </div>
   );

--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -19,8 +19,6 @@ export const DEBT_INTEREST = 0.1; // per day
 
 export const GUN_PRICE = 350; // +1 firepower
 export const ARMOR_PRICE = 280; // +1 padding (soaks damage)
-export const PATCH_HP = 25;
-export const PATCH_PRICE = 200;
 
 // You can spend this far into the red. Handy — but the bank can call the
 // overdraft at any time and seize your stash to settle it.
@@ -50,7 +48,14 @@ export const LOCATIONS = [
   "Mexico",
   "Charlotte",
   "Vanier",
-  "Casino",
+  "Barbarellas",
+  "Honest Lawyer",
+  "Minglewoods",
+  "Pier 21",
+  "Hooleys",
+  "Le Bop",
+  "Club 426",
+  "Lac Leamy Casino",
 ];
 
 export type Pending =
@@ -206,12 +211,18 @@ export function buyArmor(state: Game): Game {
   log(g, `Picked up a Kevlar hoodie. Padding is now ${g.armor}.`);
   return g;
 }
-export function patchUp(state: Game): Game {
+/** Buy a healing item: restore `hpGain` HP for `price`. */
+export function buyHeal(
+  state: Game,
+  hpGain: number,
+  price: number,
+  name: string,
+): Game {
   const g = clone(state);
-  if (g.over || availableFunds(g) < PATCH_PRICE || g.hp >= START_HP) return g;
-  g.cash -= PATCH_PRICE;
-  g.hp = Math.min(START_HP, g.hp + PATCH_HP);
-  log(g, `Patched up at the clinic. HP is now ${g.hp}.`);
+  if (g.over || availableFunds(g) < price || g.hp >= START_HP) return g;
+  g.cash -= price;
+  g.hp = Math.min(START_HP, g.hp + hpGain);
+  log(g, `${name} hit the spot. HP is now ${g.hp}.`);
   return g;
 }
 export function payShark(state: Game, amount: number): Game {


### PR DESCRIPTION
Get Mitch Quick updates:

- **Travel spots:** removed "Casino"; added **Barbarellas, Honest Lawyer, Minglewoods, Pier 21, Hooleys, Le Bop, Club 426, Lac Leamy Casino** (14 total now). The travel list is scrollable so the panel stays compact.
- **Ottawa shop items:** replaced the generic clinic patch with local late-night cures — **Shawarma** (+24 HP), **BeaverTail** (+12), **Poutine** (+18), and a **Civic ER visit** (full heal) — alongside the gear (Piece, Puffer jacket). Folded into a single `buyHeal()` helper.

Typecheck + build pass; 300-run smoke test all terminate cleanly.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_