### PR TITLE
Get Mitch Quick: add a supply (duffel capacity) upgrade

### DIFF
--- a/components/getmitchquick/GetMitchQuick.tsx
+++ b/components/getmitchquick/GetMitchQuick.tsx
@@ -5,10 +5,10 @@ import {
   GOODS,
   LOCATIONS,
   MAX_DAYS,
-  CAPACITY,
   GUN_PRICE,
   ARMOR_PRICE,
   START_HP,
+  CAP_STEP,
   type Game,
   newGame,
   buy,
@@ -16,6 +16,8 @@ import {
   buyGun,
   buyArmor,
   buyHeal,
+  buyCapacity,
+  capacityPrice,
   payShark,
   travel,
   resolveCombat,
@@ -104,7 +106,7 @@ export default function GetMitchQuick() {
           <Stat label="Debt" value={`$${g.debt.toLocaleString()}`} danger={g.debt > 0} />
           <Stat label="HP" value={`${g.hp}`} danger={g.hp <= 30} />
           <Stat label="Spot" value={LOCATIONS[g.location]} />
-          <Stat label="Duffel" value={`${usedSpace(g)}/${CAPACITY}`} />
+          <Stat label="Duffel" value={`${usedSpace(g)}/${g.capacity}`} />
           <Stat label="Firepower" value={`${g.guns}`} />
           <Stat label="Padding" value={`${g.armor}`} />
         </div>
@@ -248,9 +250,9 @@ function Market({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => void 
             <span className="ml-auto flex gap-1">
               <ActBtn onClick={() => apply((s) => buy(s, i, 1))} disabled={price == null}>+1</ActBtn>
               <ActBtn onClick={() => apply((s) => buy(s, i, 10))} disabled={price == null}>+10</ActBtn>
-              <ActBtn onClick={() => apply((s) => buy(s, i, CAPACITY))} disabled={price == null}>Max</ActBtn>
+              <ActBtn onClick={() => apply((s) => buy(s, i, g.capacity))} disabled={price == null}>Max</ActBtn>
               <ActBtn onClick={() => apply((s) => sell(s, i, 1))} disabled={owned === 0}>−1</ActBtn>
-              <ActBtn onClick={() => apply((s) => sell(s, i, CAPACITY))} disabled={owned === 0}>Sell</ActBtn>
+              <ActBtn onClick={() => apply((s) => sell(s, i, g.capacity))} disabled={owned === 0}>Sell</ActBtn>
             </span>
           </div>
         );
@@ -310,6 +312,12 @@ function Shop({ g, apply }: { g: Game; apply: (fn: (g: Game) => Game) => void })
           onClick={() => apply((s) => buyHeal(s, h.hp, h.price, h.name))}
         />
       ))}
+      <ShopRow
+        label={`Hockey bag (+${CAP_STEP} supply) — carry more`}
+        price={capacityPrice(g)}
+        disabled={availableFunds(g) < capacityPrice(g)}
+        onClick={() => apply(buyCapacity)}
+      />
       <ShopRow
         label={`Piece (+1 firepower) — fight off busts`}
         price={GUN_PRICE}

--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -69,6 +69,7 @@ export type Game = {
   hp: number;
   guns: number;
   armor: number;
+  capacity: number; // duffel size — upgradable
   coat: number[]; // qty owned per good index
   location: number;
   market: (number | null)[]; // today's price per good (null = unavailable)
@@ -93,7 +94,11 @@ const pick = <T>(g: Game, arr: T[]): T => arr[Math.floor(rnd(g) * arr.length)];
 
 // --- helpers --------------------------------------------------------------
 export const usedSpace = (g: Game) => g.coat.reduce((a, b) => a + b, 0);
-export const spaceLeft = (g: Game) => CAPACITY - usedSpace(g);
+export const spaceLeft = (g: Game) => g.capacity - usedSpace(g);
+/** Cost of the next duffel upgrade — climbs as it gets bigger. */
+export const capacityPrice = (g: Game) =>
+  300 + Math.round((g.capacity - CAPACITY) * 10);
+export const CAP_STEP = 40; // supply gained per upgrade
 /** Spendable money, including the overdraft buffer. */
 export const availableFunds = (g: Game) => g.cash + OVERDRAFT_LIMIT;
 
@@ -144,6 +149,7 @@ export function newGame(seed = (Math.random() * 1e9) | 0): Game {
     hp: START_HP,
     guns: 0,
     armor: 0,
+    capacity: CAPACITY,
     coat: GOODS.map(() => 0),
     location: 0,
     market: [],
@@ -211,6 +217,17 @@ export function buyArmor(state: Game): Game {
   log(g, `Picked up a Kevlar hoodie. Padding is now ${g.armor}.`);
   return g;
 }
+/** Buy a bigger duffel — more supply you can carry at once. */
+export function buyCapacity(state: Game): Game {
+  const g = clone(state);
+  const price = capacityPrice(g);
+  if (g.over || availableFunds(g) < price) return g;
+  g.cash -= price;
+  g.capacity += CAP_STEP;
+  log(g, `Scored a bigger hockey bag. You can now carry ${g.capacity}.`);
+  return g;
+}
+
 /** Buy a healing item: restore `hpGain` HP for `price`. */
 export function buyHeal(
   state: Game,


### PR DESCRIPTION
Adds the classic "bigger trenchcoat" upgrade that was missing — there was no way to carry more.

Duffel capacity is now a per-game stat (was a fixed 100). New **Hockey bag** shop item adds **+40 supply**, with a price that climbs each time you buy one. The duffel readout and Buy-Max now use the live capacity.

Typecheck + build pass; 300-run smoke test clean.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_