### PR TITLE
Get Mitch Quick: Ottawa-flavor antagonists and events

### DIFF
--- a/lib/getmitchquick.ts
+++ b/lib/getmitchquick.ts
@@ -255,7 +255,16 @@ export function payShark(state: Game, amount: number): Game {
 }
 
 // --- travel + events ------------------------------------------------------
-const THUGS = ["a Karen", "two mall cops", "the HOA president", "a rent-a-cop", "the Sushi Inspector"];
+const THUGS = [
+  "an OPS cruiser",
+  "an OC Transpo fare inspector",
+  "a ByWard Market bouncer",
+  "an NCC ranger",
+  "a bylaw officer",
+  "a Rideau Centre security guard",
+  "a Gatineau cop",
+  "a parking enforcer",
+];
 
 export function travel(state: Game, loc: number): Game {
   let g = clone(state);
@@ -343,8 +352,8 @@ function rollEvent(g: Game): Game {
       item: armor ? "armor" : "gun",
       price,
       label: armor
-        ? "A guy by the fountain offers a slightly-used Kevlar hoodie"
-        : "A trenchcoat guy flashes a piece for sale",
+        ? "A guy outside the Rideau Centre offers a slightly-used Kevlar hoodie"
+        : "A guy in the ByWard Market flashes a piece for sale",
     };
     log(g, `🤝 ${g.pending.label} for $${price}.`);
     return g;
@@ -353,10 +362,13 @@ function rollEvent(g: Game): Game {
   log(
     g,
     pick(g, [
-      "A quiet day. Somewhere, a mall fountain trickles.",
-      "Nothing happened. You ate a pretzel.",
-      "You overhear a tip about Fake Cologne. Probably nothing.",
-      "The food court smells of destiny and Sbarro.",
+      "A quiet day. You wait 45 minutes for an OC Transpo bus.",
+      "Nothing happened. You ate a shawarma by the Canal.",
+      "You overhear a tip in the ByWard Market. Probably nothing.",
+      "The 417 is a parking lot. You walk instead.",
+      "A Sens game lets out and the streets fill up.",
+      "It's −30 with the windchill. Everyone's inside.",
+      "You skate home on the Rideau Canal. Very Ottawa.",
     ]),
   );
   return g;


### PR DESCRIPTION
Tunes the rest of Get Mitch Quick to Ottawa (locations and shop were already done):

- **Antagonists** (busts + muggings): OPS cruiser, OC Transpo fare inspector, ByWard Market bouncer, NCC ranger, bylaw officer, Rideau Centre security guard, Gatineau cop, parking enforcer.
- **Street gear offers** pitched outside the Rideau Centre / in the ByWard Market.
- **Quiet-day flavor**: OC Transpo waits, shawarma by the Canal, the 417, Sens games letting out, −30 windchill, skating the Rideau Canal.

Typecheck + build pass; 300-run smoke test clean.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_