### PR TITLE
Add The Dam Level — TMNT NES dam stage homage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npx serve out      # preview the production build locally
 | `/flying-pig`    | **Robo Pig Attack** — a Robot Unicorn Attack-style endless runner with a winged robo-pig (jump / flap / dash) |
 | `/swole-mate`    | **Swole Mate** — a Tamagotchi-style handheld: feed/rest a little guy and grind reps for GAINS without killing him |
 | `/get-mitch-quick` | **Get Mitch Quick** — a parody of the Drug Lord / Drug Wars text trader (buy low / sell high / dodge busts / pay the shark) |
+| `/dam-level`     | **The Dam Level** — a homage to the TMNT NES underwater dam (defuse bombs, dodge electric seaweed, save your turtles) |
 | `/collage`       | Drag-and-drop collage tool (the old Pinprint), with PNG export   |
 
 ## Hosting (the slim path — $0)

--- a/app/dam-level/page.tsx
+++ b/app/dam-level/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import DemoNav from "@/components/DemoNav";
+import DamLevel from "@/components/damlevel/DamLevel";
+
+export const metadata: Metadata = {
+  title: "The Dam Level — Adam Klockars",
+  description:
+    "A homage to the infamous underwater dam level from the TMNT NES game: swim, defuse every bomb before the timer, and dodge the deadly electric seaweed. You only get four turtles.",
+};
+
+export default function DamLevelPage() {
+  return (
+    <>
+      <DemoNav />
+      <main className="mx-auto flex max-w-5xl flex-col items-center px-4 py-8 sm:px-6 sm:py-16">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-accent">
+          Play
+        </p>
+        <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
+          The Dam Level
+        </h1>
+        <p className="mt-3 hidden max-w-md text-center text-muted sm:block">
+          A loving homage to the underwater dam stage that ended so many TMNT
+          runs. Defuse every bomb before the dam blows, dodge the electric
+          seaweed, and try not to lose all four turtles.
+        </p>
+
+        <div className="mt-6 w-full sm:mt-12">
+          <DamLevel />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,6 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/flying-pig",
     "/swole-mate",
     "/get-mitch-quick",
+    "/dam-level",
   ];
   return routes.map((path) => ({
     url: `${BASE}${path}`,

--- a/components/damlevel/DamLevel.tsx
+++ b/components/damlevel/DamLevel.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Play, RotateCcw } from "lucide-react";
+import {
+  VIRT,
+  TURTLE,
+  WALLS,
+  SEAWEEDS,
+  TURTLES_START,
+  type Game,
+  type Input,
+  createGame,
+  updateGame,
+  seaweedState,
+  bombsLeft,
+  endMessage,
+} from "@/lib/damlevel";
+
+type Phase = "menu" | "playing" | "win" | "lose";
+
+const BEST_KEY = "damlevel-best";
+const HUD_H = 30;
+// Bandana colours for the four turtles.
+const COLORS = ["#2f6bff", "#ff7a1a", "#a64dff", "#ff3b3b"];
+
+type Bubble = { x: number; y: number; r: number; sp: number };
+
+export default function DamLevel() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gameRef = useRef<Game | null>(null);
+  const inputRef = useRef<Input>({ up: false, down: false, left: false, right: false });
+  const phaseRef = useRef<Phase>("menu");
+  const bubblesRef = useRef<Bubble[]>([]);
+  const rafRef = useRef<number>(0);
+  const lastRef = useRef<number>(0);
+
+  const [phase, setPhase] = useState<Phase>("menu");
+  const [best, setBest] = useState(0);
+  const [endMsg, setEndMsg] = useState("");
+  const [survivors, setSurvivors] = useState(0);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  useEffect(() => {
+    const b = Number(localStorage.getItem(BEST_KEY) || 0);
+    if (Number.isFinite(b)) setBest(b);
+  }, []);
+
+  const start = useCallback(() => {
+    gameRef.current = createGame();
+    inputRef.current = { up: false, down: false, left: false, right: false };
+    setPhase("playing");
+  }, []);
+
+  // Keyboard.
+  useEffect(() => {
+    const map: Record<string, keyof Input> = {
+      ArrowUp: "up", w: "up", W: "up",
+      ArrowDown: "down", s: "down", S: "down",
+      ArrowLeft: "left", a: "left", A: "left",
+      ArrowRight: "right", d: "right", D: "right",
+    };
+    const down = (e: KeyboardEvent) => {
+      if (e.key in map) {
+        inputRef.current[map[e.key]] = true;
+        e.preventDefault();
+      } else if ((e.key === " " || e.key === "Enter") && phaseRef.current !== "playing") {
+        start();
+        e.preventDefault();
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.key in map) inputRef.current[map[e.key]] = false;
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [start]);
+
+  // Loop.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    canvas.width = VIRT.W;
+    canvas.height = VIRT.H + HUD_H;
+    ctx.imageSmoothingEnabled = false;
+
+    if (bubblesRef.current.length === 0) {
+      bubblesRef.current = Array.from({ length: 40 }, () => ({
+        x: Math.random() * VIRT.W,
+        y: Math.random() * VIRT.H,
+        r: 1 + Math.random() * 2,
+        sp: 12 + Math.random() * 26,
+      }));
+    }
+
+    const loop = (ts: number) => {
+      rafRef.current = requestAnimationFrame(loop);
+      const last = lastRef.current || ts;
+      const dt = Math.min(0.05, (ts - last) / 1000);
+      lastRef.current = ts;
+
+      const g = gameRef.current;
+      if (g && phaseRef.current === "playing") {
+        updateGame(g, dt, inputRef.current);
+        if (g.status !== "playing") {
+          setEndMsg(endMessage(g));
+          setSurvivors(g.turtles);
+          if (g.status === "win") {
+            setBest((prev) => {
+              const nb = Math.max(prev, g.turtles);
+              localStorage.setItem(BEST_KEY, String(nb));
+              return nb;
+            });
+          }
+          setPhase(g.status);
+        }
+      }
+
+      for (const b of bubblesRef.current) {
+        b.y -= b.sp * dt;
+        if (b.y < -4) {
+          b.y = VIRT.H + 4;
+          b.x = Math.random() * VIRT.W;
+        }
+      }
+
+      draw(ctx, g, bubblesRef.current);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  const hold = (k: keyof Input, v: boolean) => (inputRef.current[k] = v);
+
+  return (
+    <div className="mx-auto w-full max-w-xl">
+      <div className="mb-3 flex items-center justify-between font-mono text-xs text-muted">
+        <span>Defuse every bomb before the dam blows. Mind the seaweed.</span>
+        <span>
+          Best:{" "}
+          <span className="font-semibold text-accent">
+            {best > 0 ? `${best} 🐢 left` : "—"}
+          </span>
+        </span>
+      </div>
+
+      <div
+        className="relative overflow-hidden rounded-xl border border-border bg-black"
+        style={{ aspectRatio: `${VIRT.W} / ${VIRT.H + HUD_H}`, boxShadow: "0 0 80px -34px #2f9e44" }}
+      >
+        <canvas
+          ref={canvasRef}
+          className="block h-full w-full"
+          style={{ imageRendering: "pixelated" }}
+        />
+
+        {phase !== "playing" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-5 text-center bg-black/70 backdrop-blur-sm">
+            {phase === "menu" ? (
+              <>
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-accent sm:text-xs">
+                  Underwater · 8-bit
+                </p>
+                <h2 className="mt-1 font-display text-2xl font-bold sm:text-4xl">
+                  The Dam Level
+                </h2>
+                <p className="mt-2 max-w-sm text-xs leading-snug text-muted sm:text-sm">
+                  Swim the dam and defuse all the bombs before the timer hits
+                  zero. The electric seaweed kills on contact — you only get four
+                  turtles. Arrows / WASD to swim.
+                </p>
+              </>
+            ) : phase === "win" ? (
+              <>
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em] sm:text-xs" style={{ color: "#7fffd4" }}>
+                  Dam defused
+                </p>
+                <h2 className="mt-1 font-display text-2xl font-bold sm:text-4xl">
+                  {survivors} 🐢 left
+                </h2>
+                <p className="mt-2 max-w-xs text-xs italic leading-snug text-muted sm:text-sm">
+                  {endMsg}
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="font-mono text-[10px] uppercase tracking-[0.3em] sm:text-xs" style={{ color: "#ff5d5d" }}>
+                  Wiped out
+                </p>
+                <h2 className="mt-1 font-display text-2xl font-bold sm:text-4xl">
+                  Game Over
+                </h2>
+                <p className="mt-2 max-w-xs text-xs italic leading-snug text-muted sm:text-sm">
+                  {endMsg}
+                </p>
+              </>
+            )}
+            <button
+              onClick={start}
+              className="mt-4 inline-flex items-center gap-2 rounded-full bg-accent px-6 py-2.5 font-medium text-background transition-transform hover:scale-[1.03] active:scale-95"
+            >
+              {phase === "menu" ? <Play className="size-4" /> : <RotateCcw className="size-4" />}
+              {phase === "menu" ? "Dive in" : "Try again"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Touch D-pad */}
+      <div className="mt-4 grid grid-cols-3 grid-rows-2 gap-2 sm:hidden" style={{ maxWidth: 220, marginInline: "auto" }}>
+        <Dpad label="↑" k="up" hold={hold} className="col-start-2 row-start-1" />
+        <Dpad label="←" k="left" hold={hold} className="col-start-1 row-start-2" />
+        <Dpad label="↓" k="down" hold={hold} className="col-start-2 row-start-2" />
+        <Dpad label="→" k="right" hold={hold} className="col-start-3 row-start-2" />
+      </div>
+
+      <p className="mt-3 hidden text-center font-mono text-xs text-faint sm:block">
+        ↑ ↓ ← → or WASD to swim · the water current never stops pushing you
+      </p>
+    </div>
+  );
+}
+
+function Dpad({
+  label,
+  k,
+  hold,
+  className,
+}: {
+  label: string;
+  k: keyof Input;
+  hold: (k: keyof Input, v: boolean) => void;
+  className?: string;
+}) {
+  return (
+    <button
+      aria-label={k}
+      className={`flex items-center justify-center rounded-lg border border-border bg-surface py-3 text-lg font-bold text-foreground active:bg-surface-2 ${className ?? ""}`}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        hold(k, true);
+      }}
+      onPointerUp={() => hold(k, false)}
+      onPointerLeave={() => hold(k, false)}
+      onPointerCancel={() => hold(k, false)}
+    >
+      {label}
+    </button>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Pixel rendering
+// --------------------------------------------------------------------------
+function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) {
+  // HUD bar.
+  ctx.fillStyle = "#081627";
+  ctx.fillRect(0, 0, VIRT.W, HUD_H);
+  ctx.font = "12px ui-monospace, monospace";
+  ctx.textBaseline = "middle";
+  if (g) {
+    ctx.fillStyle = g.time < 15 ? "#ff5d5d" : "#7fffd4";
+    ctx.fillText(`TIME ${Math.ceil(g.time)}`, 8, HUD_H / 2);
+    ctx.fillStyle = "#ffe066";
+    ctx.fillText(`BOMBS ${bombsLeft(g)}`, 110, HUD_H / 2);
+    for (let i = 0; i < TURTLES_START; i++) {
+      ctx.fillStyle = i < g.turtles ? COLORS[i] : "#1c2937";
+      ctx.fillRect(VIRT.W - 104 + i * 26, 9, 18, 13);
+      ctx.fillStyle = "#06101c";
+      ctx.fillRect(VIRT.W - 104 + i * 26 + 4, 13, 10, 4); // bandana slit
+    }
+  }
+
+  ctx.save();
+  ctx.translate(0, HUD_H);
+
+  // Water.
+  const grad = ctx.createLinearGradient(0, 0, 0, VIRT.H);
+  grad.addColorStop(0, "#0b3a63");
+  grad.addColorStop(1, "#06243f");
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, VIRT.W, VIRT.H);
+
+  for (const b of bubbles) {
+    ctx.fillStyle = "rgba(160,220,255,0.18)";
+    ctx.fillRect(Math.floor(b.x), Math.floor(b.y), b.r, b.r);
+  }
+
+  // Dam walls (gray with rivets).
+  for (const w of WALLS) {
+    ctx.fillStyle = "#5b6675";
+    ctx.fillRect(w.x, w.y, w.w, w.h);
+    ctx.fillStyle = "#454e5b";
+    ctx.fillRect(w.x, w.y, 3, w.h);
+    ctx.fillStyle = "#7a8694";
+    for (let ry = w.y + 8; ry < w.y + w.h - 4; ry += 18) {
+      ctx.fillRect(w.x + w.w / 2 - 1, ry, 2, 2);
+    }
+  }
+
+  if (g) {
+    // Electric seaweed.
+    for (const sw of SEAWEEDS) {
+      const st = seaweedState(g.gameTime, sw);
+      const zap = st === 2;
+      const warn = st === 1;
+      let col = "#2f9e44";
+      if (zap) col = (Math.floor(g.gameTime * 30) % 2 ? "#ffffff" : "#ffe04d");
+      else if (warn) col = (Math.floor(g.gameTime * 18) % 2 ? "#a7e34d" : "#2f9e44");
+      // Wavy strand.
+      for (let yy = 0; yy < sw.h; yy += 6) {
+        const wob = Math.sin((g.gameTime * 3 + (sw.y + yy) * 0.15)) * 2;
+        ctx.fillStyle = col;
+        ctx.fillRect(Math.round(sw.x + wob), sw.y + yy, sw.w, 6);
+      }
+      if (zap) {
+        ctx.fillStyle = "#bfefff";
+        for (let s = 0; s < 4; s++) {
+          ctx.fillRect(
+            sw.x - 3 + Math.floor(Math.random() * (sw.w + 6)),
+            sw.y + Math.floor(Math.random() * sw.h),
+            2,
+            2,
+          );
+        }
+      }
+    }
+
+    // Bombs.
+    for (const b of g.bombs) {
+      if (b.defused) {
+        ctx.fillStyle = "#3a4654";
+        circle(ctx, b.x, b.y, 6);
+        ctx.fillStyle = "#7fffd4";
+        ctx.fillRect(b.x - 3, b.y, 2, 2);
+        ctx.fillRect(b.x - 1, b.y + 2, 2, 2);
+        ctx.fillRect(b.x + 1, b.y - 2, 2, 4);
+      } else {
+        ctx.fillStyle = "#15181d";
+        circle(ctx, b.x, b.y, 7);
+        ctx.fillStyle = "#444";
+        ctx.fillRect(b.x - 1, b.y - 9, 2, 3); // fuse cap
+        const blink = Math.floor(g.gameTime * 4) % 2 === 0;
+        ctx.fillStyle = blink ? "#ff3b3b" : "#7a1f1f";
+        ctx.fillRect(b.x - 2, b.y - 2, 3, 3); // light
+      }
+    }
+
+    // Turtle (blinks while invulnerable).
+    const blink = g.invuln > 0 && Math.floor(g.gameTime * 12) % 2 === 0;
+    if (!blink) drawTurtle(ctx, g);
+
+    // Death flash.
+    if (g.flash > 0) {
+      ctx.fillStyle = `rgba(255,40,40,${(g.flash / 0.25) * 0.4})`;
+      ctx.fillRect(0, 0, VIRT.W, VIRT.H);
+    }
+  }
+
+  ctx.restore();
+}
+
+function circle(ctx: CanvasRenderingContext2D, x: number, y: number, r: number) {
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawTurtle(ctx: CanvasRenderingContext2D, g: Game) {
+  const x = g.x;
+  const y = g.y;
+  const w = TURTLE.W;
+  const h = TURTLE.H;
+  const color = COLORS[TURTLES_START - g.turtles] ?? COLORS[3];
+
+  // Shell.
+  ctx.fillStyle = "#1f7a2e";
+  ctx.fillRect(x + 2, y + 2, w - 4, h - 3);
+  ctx.fillStyle = "#2fae45";
+  ctx.fillRect(x + 4, y + 4, w - 8, h - 7);
+  // shell segments
+  ctx.fillStyle = "#1a5c25";
+  ctx.fillRect(x + w / 2 - 1, y + 3, 2, h - 5);
+
+  // Head (faces heading).
+  const hx = g.facing > 0 ? x + w - 3 : x - 3;
+  ctx.fillStyle = "#36c24f";
+  ctx.fillRect(hx, y + 4, 5, 6);
+  // bandana
+  ctx.fillStyle = color;
+  ctx.fillRect(hx - (g.facing > 0 ? 0 : 0), y + 4, 5, 2);
+  // eye
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(hx + (g.facing > 0 ? 2 : 1), y + 6, 2, 2);
+
+  // Limbs.
+  ctx.fillStyle = "#36c24f";
+  ctx.fillRect(x, y + h - 4, 3, 3);
+  ctx.fillRect(x + w - 3, y + h - 4, 3, 3);
+}

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -7,6 +7,7 @@ import {
   PiggyBank,
   Dumbbell,
   DollarSign,
+  Bomb,
 } from "lucide-react";
 import { Reveal } from "@/components/ui/Reveal";
 
@@ -50,6 +51,14 @@ const experiments = [
       "A parody of the old DOS text trader Drug Lord / Drug Wars: buy low and sell high, dodge escalating busts, ride the overdraft, pay off the loan shark, and get Mitch quick before it gets you.",
     icon: DollarSign,
     accent: "#ffb000",
+  },
+  {
+    href: "/dam-level",
+    title: "The Dam Level",
+    blurb:
+      "A homage to the underwater dam stage that ended so many TMNT runs. Swim the floaty current, defuse every bomb before the timer, and dodge the electric seaweed — you only get four turtles, and the seaweed wants them all.",
+    icon: Bomb,
+    accent: "#2dd4bf",
   },
   {
     href: "/collage",

--- a/lib/damlevel.ts
+++ b/lib/damlevel.ts
@@ -1,0 +1,244 @@
+// Game logic for "Dam Level" — a homage to the infamous underwater dam stage
+// from the 1989 TMNT NES game: swim with floaty water physics, defuse every
+// bomb before the timer blows the dam, and weave through deadly electric
+// seaweed. You get four turtles. The seaweed will take most of them — and
+// finishing the dam with one turtle left to beat the rest of the game is, of
+// course, the whole point.
+
+export const VIRT = { W: 480, H: 360 } as const;
+
+export const TURTLE = { W: 18, H: 16 } as const;
+export const TURTLES_START = 4;
+export const TIME_START = 75; // seconds on the bomb timer
+
+// Floaty water movement.
+const ACCEL = 560; // px/s² while a direction is held
+const DRAG = 3.2; // water resistance (low = floaty momentum)
+const MAX_SPEED = 155;
+const CURRENT_X = 34; // constant drift — you're always fighting the current
+const CURRENT_Y = 20;
+
+const RESPAWN_INVULN = 1.6; // seconds of safety after losing a turtle
+
+const START = { x: 18, y: 168 };
+
+export type Rect = { x: number; y: number; w: number; h: number };
+export type Seaweed = Rect & { phase: number };
+export type Bomb = { x: number; y: number; defused: boolean };
+export type Status = "playing" | "win" | "lose";
+export type LoseCause = "" | "time" | "dead";
+
+// --- Fixed level layout (hand-designed so it's always solvable) -----------
+// Gray dam walls with gaps; the gaps and chambers all hold electric seaweed.
+export const WALLS: Rect[] = [
+  { x: 150, y: 0, w: 16, h: 120 },
+  { x: 150, y: 180, w: 16, h: 180 }, // gap y120..180
+  { x: 320, y: 0, w: 16, h: 200 },
+  { x: 320, y: 270, w: 16, h: 90 }, // gap y200..270
+];
+
+export const SEAWEEDS: Seaweed[] = [
+  { x: 90, y: 0, w: 8, h: 150, phase: 0.0 },
+  { x: 112, y: 230, w: 8, h: 130, phase: 1.2 },
+  { x: 240, y: 0, w: 8, h: 120, phase: 0.6 },
+  { x: 210, y: 200, w: 8, h: 160, phase: 1.8 },
+  { x: 392, y: 0, w: 8, h: 160, phase: 0.3 },
+  { x: 420, y: 200, w: 8, h: 160, phase: 1.5 },
+  { x: 156, y: 120, w: 8, h: 60, phase: 0.9 }, // in wall-A gap
+  { x: 326, y: 200, w: 8, h: 70, phase: 0.4 }, // in wall-B gap
+];
+
+const BOMB_SPOTS: { x: number; y: number }[] = [
+  { x: 44, y: 60 },
+  { x: 60, y: 305 },
+  { x: 200, y: 60 },
+  { x: 232, y: 145 },
+  { x: 250, y: 310 },
+  { x: 380, y: 90 },
+  { x: 404, y: 184 },
+  { x: 432, y: 300 },
+];
+
+// Electric seaweed cycle: mostly safe, brief warning, then a deadly zap.
+const SW_CYCLE = 2.4;
+const SW_WARN = 1.6;
+const SW_ZAP = 1.95;
+/** 0 = safe, 1 = warning (about to zap), 2 = zapping (deadly). */
+export function seaweedState(time: number, sw: Seaweed): 0 | 1 | 2 {
+  const t = (time + sw.phase * 0.83) % SW_CYCLE;
+  if (t < SW_WARN) return 0;
+  if (t < SW_ZAP) return 1;
+  return 2;
+}
+
+export type Input = { up: boolean; down: boolean; left: boolean; right: boolean };
+
+export type Game = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  facing: 1 | -1; // last horizontal heading, for drawing
+  bombs: Bomb[];
+  turtles: number; // turtles remaining (current one included)
+  time: number;
+  status: Status;
+  cause: LoseCause;
+  invuln: number;
+  gameTime: number; // drives seaweed pulsing
+  flash: number; // brief red flash timer on a death
+};
+
+function overlaps(
+  ax: number,
+  ay: number,
+  aw: number,
+  ah: number,
+  b: Rect,
+): boolean {
+  return ax < b.x + b.w && ax + aw > b.x && ay < b.y + b.h && ay + ah > b.y;
+}
+
+export function createGame(): Game {
+  return {
+    x: START.x,
+    y: START.y,
+    vx: 0,
+    vy: 0,
+    facing: 1,
+    bombs: BOMB_SPOTS.map((s) => ({ x: s.x, y: s.y, defused: false })),
+    turtles: TURTLES_START,
+    time: TIME_START,
+    status: "playing",
+    cause: "",
+    invuln: RESPAWN_INVULN,
+    gameTime: 0,
+    flash: 0,
+  };
+}
+
+export const bombsLeft = (g: Game) => g.bombs.filter((b) => !b.defused).length;
+
+function respawn(g: Game) {
+  g.x = START.x;
+  g.y = START.y;
+  g.vx = 0;
+  g.vy = 0;
+  g.invuln = RESPAWN_INVULN;
+}
+
+function killTurtle(g: Game) {
+  g.turtles -= 1;
+  g.flash = 0.25;
+  if (g.turtles <= 0) {
+    g.turtles = 0;
+    g.status = "lose";
+    g.cause = "dead";
+  } else {
+    respawn(g);
+  }
+}
+
+export function updateGame(g: Game, dt: number, input: Input): Game {
+  if (g.status !== "playing") return g;
+
+  g.gameTime += dt;
+  if (g.flash > 0) g.flash = Math.max(0, g.flash - dt);
+  if (g.invuln > 0) g.invuln = Math.max(0, g.invuln - dt);
+
+  // Movement: held direction + current, with floaty drag.
+  const ix = (input.right ? 1 : 0) - (input.left ? 1 : 0);
+  const iy = (input.down ? 1 : 0) - (input.up ? 1 : 0);
+  g.vx += (ix * ACCEL + CURRENT_X) * dt;
+  g.vy += (iy * ACCEL + CURRENT_Y) * dt;
+  const dragF = 1 / (1 + DRAG * dt);
+  g.vx *= dragF;
+  g.vy *= dragF;
+  const sp = Math.hypot(g.vx, g.vy);
+  if (sp > MAX_SPEED) {
+    g.vx = (g.vx / sp) * MAX_SPEED;
+    g.vy = (g.vy / sp) * MAX_SPEED;
+  }
+  if (ix !== 0) g.facing = ix > 0 ? 1 : -1;
+
+  // Integrate + resolve, one axis at a time so wall sliding feels right.
+  g.x += g.vx * dt;
+  if (g.x < 0) {
+    g.x = 0;
+    g.vx = 0;
+  }
+  if (g.x > VIRT.W - TURTLE.W) {
+    g.x = VIRT.W - TURTLE.W;
+    g.vx = 0;
+  }
+  for (const w of WALLS) {
+    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, w)) {
+      if (g.vx > 0) g.x = w.x - TURTLE.W;
+      else if (g.vx < 0) g.x = w.x + w.w;
+      g.vx = 0;
+    }
+  }
+  g.y += g.vy * dt;
+  if (g.y < 0) {
+    g.y = 0;
+    g.vy = 0;
+  }
+  if (g.y > VIRT.H - TURTLE.H) {
+    g.y = VIRT.H - TURTLE.H;
+    g.vy = 0;
+  }
+  for (const w of WALLS) {
+    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, w)) {
+      if (g.vy > 0) g.y = w.y - TURTLE.H;
+      else if (g.vy < 0) g.y = w.y + w.h;
+      g.vy = 0;
+    }
+  }
+
+  // Electric seaweed (deadly only mid-zap; harmless while invulnerable).
+  if (g.invuln <= 0) {
+    for (const sw of SEAWEEDS) {
+      if (
+        seaweedState(g.gameTime, sw) === 2 &&
+        overlaps(g.x, g.y, TURTLE.W, TURTLE.H, sw)
+      ) {
+        killTurtle(g);
+        break;
+      }
+    }
+  }
+  if (g.status !== "playing") return g;
+
+  // Defuse bombs on contact.
+  for (const b of g.bombs) {
+    if (b.defused) continue;
+    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, { x: b.x - 8, y: b.y - 8, w: 16, h: 16 })) {
+      b.defused = true;
+    }
+  }
+  if (bombsLeft(g) === 0) {
+    g.status = "win";
+    return g;
+  }
+
+  // The bomb timer.
+  g.time -= dt;
+  if (g.time <= 0) {
+    g.time = 0;
+    g.status = "lose";
+    g.cause = "time";
+  }
+  return g;
+}
+
+/** A cheeky end-of-run line. */
+export function endMessage(g: Game): string {
+  if (g.status === "win") {
+    if (g.turtles >= 4) return "Not a scratch. Suspicious.";
+    if (g.turtles === 3) return "Down a turtle already. The dam's just warming up.";
+    if (g.turtles === 2) return "Two turtles left. The seaweed ate the rest.";
+    return "One turtle left to beat the ENTIRE rest of the game. Classic.";
+  }
+  if (g.cause === "time") return "💥 The dam blew. Should've swum faster.";
+  return "All four turtles fried by the seaweed. The dam wins again.";
+}


### PR DESCRIPTION
Adds **The Dam Level** at `/dam-level` — a homage to the infamous underwater dam stage from the 1989 TMNT NES game (the one that ate everyone's turtles).

## Gameplay
- Swim a single-screen dam with **floaty, current-fighting water physics**.
- **Defuse all the bombs before the timer** blows the dam.
- **Electric seaweed** pulses (safe → brief warning → deadly zap) and kills on contact.
- You get **four turtles**. Lose one to the seaweed and you respawn (bomb progress kept) until they're all gone. Clearing the dam with one turtle left to beat the rest of the game is the whole joke — the end screen calls it out.

## Details
- Pure logic + a **hand-designed, always-solvable** level in `lib/damlevel.ts`. Smoke-tested for the win, timer-loss, and seaweed-death paths.
- Canvas **8-bit pixel** renderer: gray dam walls, wavy electric seaweed that telegraphs before zapping, blinking bombs, a turtle that faces its heading, bubbles, and a HUD with timer / bomb count / turtle lives.
- **Keyboard** (arrows/WASD) + on-screen **D-pad** for touch. Best = most turtles left on a win, saved to `localStorage`.
- Wired into the Play section, sitemap, and README. Typecheck + build pass.

Note: it's an homage with generically-colored turtles — no trademarked names.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_