### PR TITLE
The Damn Level: platypuses, scrolling maze, harder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npx serve out      # preview the production build locally
 | `/flying-pig`    | **Robo Pig Attack** — a Robot Unicorn Attack-style endless runner with a winged robo-pig (jump / flap / dash) |
 | `/swole-mate`    | **Swole Mate** — a Tamagotchi-style handheld: feed/rest a little guy and grind reps for GAINS without killing him |
 | `/get-mitch-quick` | **Get Mitch Quick** — a parody of the Drug Lord / Drug Wars text trader (buy low / sell high / dodge busts / pay the shark) |
-| `/dam-level`     | **The Dam Level** — a homage to the TMNT NES underwater dam (defuse bombs, dodge electric seaweed, save your turtles) |
+| `/damn-level`    | **The Damn Level** — a homage to the TMNT NES underwater dam, with platypuses (scrolling maze, defuse bombs, dodge electric seaweed) |
 | `/collage`       | Drag-and-drop collage tool (the old Pinprint), with PNG export   |
 
 ## Hosting (the slim path — $0)

--- a/app/damn-level/page.tsx
+++ b/app/damn-level/page.tsx
@@ -3,12 +3,12 @@ import DemoNav from "@/components/DemoNav";
 import DamLevel from "@/components/damlevel/DamLevel";
 
 export const metadata: Metadata = {
-  title: "The Dam Level — Adam Klockars",
+  title: "The Damn Level — Adam Klockars",
   description:
-    "A homage to the infamous underwater dam level from the TMNT NES game: swim, defuse every bomb before the timer, and dodge the deadly electric seaweed. You only get four turtles.",
+    "A homage to the infamous underwater dam level from the TMNT NES game, with platypuses: swim a scrolling dam maze, defuse every bomb before the timer, and dodge the deadly electric seaweed. You only get four platypuses.",
 };
 
-export default function DamLevelPage() {
+export default function DamnLevelPage() {
   return (
     <>
       <DemoNav />
@@ -17,12 +17,13 @@ export default function DamLevelPage() {
           Play
         </p>
         <h1 className="mt-3 font-display text-3xl font-bold tracking-tight sm:text-5xl">
-          The Dam Level
+          The Damn Level
         </h1>
         <p className="mt-3 hidden max-w-md text-center text-muted sm:block">
-          A loving homage to the underwater dam stage that ended so many TMNT
-          runs. Defuse every bomb before the dam blows, dodge the electric
-          seaweed, and try not to lose all four turtles.
+          A loving homage to the underwater dam stage that ended so many runs —
+          now with platypuses. Swim the scrolling dam maze, defuse every bomb
+          before the dam blows, dodge the electric seaweed, and try not to lose
+          all four platypuses.
         </p>
 
         <div className="mt-6 w-full sm:mt-12">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,7 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/flying-pig",
     "/swole-mate",
     "/get-mitch-quick",
-    "/dam-level",
+    "/damn-level",
   ];
   return routes.map((path) => ({
     url: `${BASE}${path}`,

--- a/components/damlevel/DamLevel.tsx
+++ b/components/damlevel/DamLevel.tsx
@@ -3,11 +3,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Play, RotateCcw } from "lucide-react";
 import {
-  VIRT,
-  TURTLE,
+  WORLD,
+  PLATY,
   WALLS,
   SEAWEEDS,
-  TURTLES_START,
+  PLATYPUS_START,
   type Game,
   type Input,
   createGame,
@@ -21,7 +21,8 @@ type Phase = "menu" | "playing" | "win" | "lose";
 
 const BEST_KEY = "damlevel-best";
 const HUD_H = 30;
-// Bandana colours for the four turtles.
+const VIEW = { W: 480, H: 360 }; // scrolling window into the world
+// Marker colours for the four platypuses.
 const COLORS = ["#2f6bff", "#ff7a1a", "#a64dff", "#ff3b3b"];
 
 type Bubble = { x: number; y: number; r: number; sp: number };
@@ -89,14 +90,14 @@ export default function DamLevel() {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    canvas.width = VIRT.W;
-    canvas.height = VIRT.H + HUD_H;
+    canvas.width = VIEW.W;
+    canvas.height = VIEW.H + HUD_H;
     ctx.imageSmoothingEnabled = false;
 
     if (bubblesRef.current.length === 0) {
-      bubblesRef.current = Array.from({ length: 40 }, () => ({
-        x: Math.random() * VIRT.W,
-        y: Math.random() * VIRT.H,
+      bubblesRef.current = Array.from({ length: 36 }, () => ({
+        x: Math.random() * VIEW.W,
+        y: Math.random() * VIEW.H,
         r: 1 + Math.random() * 2,
         sp: 12 + Math.random() * 26,
       }));
@@ -113,10 +114,10 @@ export default function DamLevel() {
         updateGame(g, dt, inputRef.current);
         if (g.status !== "playing") {
           setEndMsg(endMessage(g));
-          setSurvivors(g.turtles);
+          setSurvivors(g.platypuses);
           if (g.status === "win") {
             setBest((prev) => {
-              const nb = Math.max(prev, g.turtles);
+              const nb = Math.max(prev, g.platypuses);
               localStorage.setItem(BEST_KEY, String(nb));
               return nb;
             });
@@ -128,8 +129,8 @@ export default function DamLevel() {
       for (const b of bubblesRef.current) {
         b.y -= b.sp * dt;
         if (b.y < -4) {
-          b.y = VIRT.H + 4;
-          b.x = Math.random() * VIRT.W;
+          b.y = VIEW.H + 4;
+          b.x = Math.random() * VIEW.W;
         }
       }
 
@@ -148,14 +149,14 @@ export default function DamLevel() {
         <span>
           Best:{" "}
           <span className="font-semibold text-accent">
-            {best > 0 ? `${best} 🐢 left` : "—"}
+            {best > 0 ? `${best} left` : "—"}
           </span>
         </span>
       </div>
 
       <div
         className="relative overflow-hidden rounded-xl border border-border bg-black"
-        style={{ aspectRatio: `${VIRT.W} / ${VIRT.H + HUD_H}`, boxShadow: "0 0 80px -34px #2f9e44" }}
+        style={{ aspectRatio: `${VIEW.W} / ${VIEW.H + HUD_H}`, boxShadow: "0 0 80px -34px #2f9e44" }}
       >
         <canvas
           ref={canvasRef}
@@ -171,12 +172,13 @@ export default function DamLevel() {
                   Underwater · 8-bit
                 </p>
                 <h2 className="mt-1 font-display text-2xl font-bold sm:text-4xl">
-                  The Dam Level
+                  The Damn Level
                 </h2>
                 <p className="mt-2 max-w-sm text-xs leading-snug text-muted sm:text-sm">
-                  Swim the dam and defuse all the bombs before the timer hits
-                  zero. The electric seaweed kills on contact — you only get four
-                  turtles. Arrows / WASD to swim.
+                  Swim the dam maze and defuse all the bombs before the timer
+                  hits zero. The electric seaweed kills on contact — you only get
+                  four platypuses. Arrows / WASD to swim; the view scrolls with
+                  you.
                 </p>
               </>
             ) : phase === "win" ? (
@@ -185,7 +187,7 @@ export default function DamLevel() {
                   Dam defused
                 </p>
                 <h2 className="mt-1 font-display text-2xl font-bold sm:text-4xl">
-                  {survivors} 🐢 left
+                  {survivors} platypus{survivors === 1 ? "" : "es"} left
                 </h2>
                 <p className="mt-2 max-w-xs text-xs italic leading-snug text-muted sm:text-sm">
                   {endMsg}
@@ -224,7 +226,8 @@ export default function DamLevel() {
       </div>
 
       <p className="mt-3 hidden text-center font-mono text-xs text-faint sm:block">
-        ↑ ↓ ← → or WASD to swim · the water current never stops pushing you
+        ↑ ↓ ← → or WASD to swim · the current never stops pushing you · the view
+        scrolls with your platypus
       </p>
     </div>
   );
@@ -259,12 +262,12 @@ function Dpad({
 }
 
 // --------------------------------------------------------------------------
-// Pixel rendering
+// Pixel rendering with a scrolling camera
 // --------------------------------------------------------------------------
 function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) {
   // HUD bar.
   ctx.fillStyle = "#081627";
-  ctx.fillRect(0, 0, VIRT.W, HUD_H);
+  ctx.fillRect(0, 0, VIEW.W, HUD_H);
   ctx.font = "12px ui-monospace, monospace";
   ctx.textBaseline = "middle";
   if (g) {
@@ -272,30 +275,43 @@ function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) 
     ctx.fillText(`TIME ${Math.ceil(g.time)}`, 8, HUD_H / 2);
     ctx.fillStyle = "#ffe066";
     ctx.fillText(`BOMBS ${bombsLeft(g)}`, 110, HUD_H / 2);
-    for (let i = 0; i < TURTLES_START; i++) {
-      ctx.fillStyle = i < g.turtles ? COLORS[i] : "#1c2937";
-      ctx.fillRect(VIRT.W - 104 + i * 26, 9, 18, 13);
+    for (let i = 0; i < PLATYPUS_START; i++) {
+      ctx.fillStyle = i < g.platypuses ? COLORS[i] : "#1c2937";
+      ctx.fillRect(VIEW.W - 104 + i * 26, 9, 18, 13);
       ctx.fillStyle = "#06101c";
-      ctx.fillRect(VIRT.W - 104 + i * 26 + 4, 13, 10, 4); // bandana slit
+      ctx.fillRect(VIEW.W - 104 + i * 26 + 12, 12, 6, 4); // little bill
     }
   }
 
+  // Camera follows the platypus, clamped to the world.
+  let camX = 0, camY = 0;
+  if (g) {
+    camX = Math.max(0, Math.min(WORLD.W - VIEW.W, g.x + PLATY.W / 2 - VIEW.W / 2));
+    camY = Math.max(0, Math.min(WORLD.H - VIEW.H, g.y + PLATY.H / 2 - VIEW.H / 2));
+  }
+
   ctx.save();
+  // Clip to the play viewport so the world never bleeds into the HUD.
+  ctx.beginPath();
+  ctx.rect(0, HUD_H, VIEW.W, VIEW.H);
+  ctx.clip();
   ctx.translate(0, HUD_H);
 
-  // Water.
-  const grad = ctx.createLinearGradient(0, 0, 0, VIRT.H);
+  // Water (screen space).
+  const grad = ctx.createLinearGradient(0, 0, 0, VIEW.H);
   grad.addColorStop(0, "#0b3a63");
   grad.addColorStop(1, "#06243f");
   ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, VIRT.W, VIRT.H);
-
+  ctx.fillRect(0, 0, VIEW.W, VIEW.H);
   for (const b of bubbles) {
     ctx.fillStyle = "rgba(160,220,255,0.18)";
     ctx.fillRect(Math.floor(b.x), Math.floor(b.y), b.r, b.r);
   }
 
-  // Dam walls (gray with rivets).
+  // World space.
+  ctx.save();
+  ctx.translate(-camX, -camY);
+
   for (const w of WALLS) {
     ctx.fillStyle = "#5b6675";
     ctx.fillRect(w.x, w.y, w.w, w.h);
@@ -308,21 +324,17 @@ function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) 
   }
 
   if (g) {
-    // Electric seaweed.
     for (const sw of SEAWEEDS) {
       const st = seaweedState(g.gameTime, sw);
-      const zap = st === 2;
-      const warn = st === 1;
       let col = "#2f9e44";
-      if (zap) col = (Math.floor(g.gameTime * 30) % 2 ? "#ffffff" : "#ffe04d");
-      else if (warn) col = (Math.floor(g.gameTime * 18) % 2 ? "#a7e34d" : "#2f9e44");
-      // Wavy strand.
+      if (st === 2) col = Math.floor(g.gameTime * 30) % 2 ? "#ffffff" : "#ffe04d";
+      else if (st === 1) col = Math.floor(g.gameTime * 18) % 2 ? "#a7e34d" : "#2f9e44";
       for (let yy = 0; yy < sw.h; yy += 6) {
-        const wob = Math.sin((g.gameTime * 3 + (sw.y + yy) * 0.15)) * 2;
+        const wob = Math.sin(g.gameTime * 3 + (sw.y + yy) * 0.15) * 2;
         ctx.fillStyle = col;
         ctx.fillRect(Math.round(sw.x + wob), sw.y + yy, sw.w, 6);
       }
-      if (zap) {
+      if (st === 2) {
         ctx.fillStyle = "#bfefff";
         for (let s = 0; s < 4; s++) {
           ctx.fillRect(
@@ -335,7 +347,6 @@ function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) 
       }
     }
 
-    // Bombs.
     for (const b of g.bombs) {
       if (b.defused) {
         ctx.fillStyle = "#3a4654";
@@ -348,25 +359,25 @@ function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) 
         ctx.fillStyle = "#15181d";
         circle(ctx, b.x, b.y, 7);
         ctx.fillStyle = "#444";
-        ctx.fillRect(b.x - 1, b.y - 9, 2, 3); // fuse cap
+        ctx.fillRect(b.x - 1, b.y - 9, 2, 3);
         const blink = Math.floor(g.gameTime * 4) % 2 === 0;
         ctx.fillStyle = blink ? "#ff3b3b" : "#7a1f1f";
-        ctx.fillRect(b.x - 2, b.y - 2, 3, 3); // light
+        ctx.fillRect(b.x - 2, b.y - 2, 3, 3);
       }
     }
 
-    // Turtle (blinks while invulnerable).
     const blink = g.invuln > 0 && Math.floor(g.gameTime * 12) % 2 === 0;
-    if (!blink) drawTurtle(ctx, g);
-
-    // Death flash.
-    if (g.flash > 0) {
-      ctx.fillStyle = `rgba(255,40,40,${(g.flash / 0.25) * 0.4})`;
-      ctx.fillRect(0, 0, VIRT.W, VIRT.H);
-    }
+    if (!blink) drawPlatypus(ctx, g);
   }
 
-  ctx.restore();
+  ctx.restore(); // world
+
+  if (g && g.flash > 0) {
+    ctx.fillStyle = `rgba(255,40,40,${(g.flash / 0.25) * 0.4})`;
+    ctx.fillRect(0, 0, VIEW.W, VIEW.H);
+  }
+
+  ctx.restore(); // clip + HUD translate
 }
 
 function circle(ctx: CanvasRenderingContext2D, x: number, y: number, r: number) {
@@ -375,35 +386,36 @@ function circle(ctx: CanvasRenderingContext2D, x: number, y: number, r: number) 
   ctx.fill();
 }
 
-function drawTurtle(ctx: CanvasRenderingContext2D, g: Game) {
+function drawPlatypus(ctx: CanvasRenderingContext2D, g: Game) {
   const x = g.x;
   const y = g.y;
-  const w = TURTLE.W;
-  const h = TURTLE.H;
-  const color = COLORS[TURTLES_START - g.turtles] ?? COLORS[3];
+  const w = PLATY.W;
+  const h = PLATY.H;
+  const f = g.facing; // 1 = right, -1 = left
+  const color = COLORS[PLATYPUS_START - g.platypuses] ?? COLORS[3];
 
-  // Shell.
-  ctx.fillStyle = "#1f7a2e";
-  ctx.fillRect(x + 2, y + 2, w - 4, h - 3);
-  ctx.fillStyle = "#2fae45";
-  ctx.fillRect(x + 4, y + 4, w - 8, h - 7);
-  // shell segments
-  ctx.fillStyle = "#1a5c25";
-  ctx.fillRect(x + w / 2 - 1, y + 3, 2, h - 5);
+  // Body.
+  ctx.fillStyle = "#8a5a2b";
+  ctx.fillRect(x + 3, y + 2, w - 6, h - 3);
+  ctx.fillStyle = "#a06d34";
+  ctx.fillRect(x + 5, y + 3, w - 10, h - 6);
 
-  // Head (faces heading).
-  const hx = g.facing > 0 ? x + w - 3 : x - 3;
-  ctx.fillStyle = "#36c24f";
-  ctx.fillRect(hx, y + 4, 5, 6);
-  // bandana
+  // Flat tail (behind, opposite facing).
+  ctx.fillStyle = "#6b4521";
+  const tailX = f > 0 ? x : x + w - 4;
+  ctx.fillRect(tailX, y + 4, 4, h - 6);
+
+  // Duck bill (front, in facing direction).
+  ctx.fillStyle = "#3a2a18";
+  const billX = f > 0 ? x + w - 5 : x;
+  ctx.fillRect(billX, y + 5, 5, 4);
+
+  // Head bump + colour marker (homage headband).
+  const headX = f > 0 ? x + w - 9 : x + 4;
   ctx.fillStyle = color;
-  ctx.fillRect(hx - (g.facing > 0 ? 0 : 0), y + 4, 5, 2);
-  // eye
-  ctx.fillStyle = "#fff";
-  ctx.fillRect(hx + (g.facing > 0 ? 2 : 1), y + 6, 2, 2);
+  ctx.fillRect(headX, y + 1, 5, 2);
 
-  // Limbs.
-  ctx.fillStyle = "#36c24f";
-  ctx.fillRect(x, y + h - 4, 3, 3);
-  ctx.fillRect(x + w - 3, y + h - 4, 3, 3);
+  // Eye.
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(f > 0 ? x + w - 8 : x + 5, y + 4, 2, 2);
 }

--- a/components/landing/PlaySection.tsx
+++ b/components/landing/PlaySection.tsx
@@ -53,10 +53,10 @@ const experiments = [
     accent: "#ffb000",
   },
   {
-    href: "/dam-level",
-    title: "The Dam Level",
+    href: "/damn-level",
+    title: "The Damn Level",
     blurb:
-      "A homage to the underwater dam stage that ended so many TMNT runs. Swim the floaty current, defuse every bomb before the timer, and dodge the electric seaweed — you only get four turtles, and the seaweed wants them all.",
+      "A homage to the underwater dam stage that ended so many TMNT runs — but with platypuses. Swim a scrolling dam maze, defuse every bomb before the timer, and dodge the electric seaweed — you only get four platypuses, and the seaweed wants them all.",
     icon: Bomb,
     accent: "#2dd4bf",
   },

--- a/lib/damlevel.ts
+++ b/lib/damlevel.ts
@@ -1,26 +1,26 @@
-// Game logic for "Dam Level" — a homage to the infamous underwater dam stage
-// from the 1989 TMNT NES game: swim with floaty water physics, defuse every
-// bomb before the timer blows the dam, and weave through deadly electric
-// seaweed. You get four turtles. The seaweed will take most of them — and
-// finishing the dam with one turtle left to beat the rest of the game is, of
-// course, the whole point.
+// Game logic for "The Damn Level" — a homage to the infamous underwater dam
+// stage from the 1989 TMNT NES game, only with platypuses. The world is a
+// large scrolling maze (the camera follows you in all four directions); swim
+// the floaty current, defuse every bomb before the timer blows the dam, and
+// weave through deadly electric seaweed. You get four platypuses. The seaweed
+// will take most of them.
 
-export const VIRT = { W: 480, H: 360 } as const;
+// The whole level — bigger than the viewport, so the camera scrolls.
+export const WORLD = { W: 960, H: 720 } as const;
 
-export const TURTLE = { W: 18, H: 16 } as const;
-export const TURTLES_START = 4;
-export const TIME_START = 75; // seconds on the bomb timer
+export const PLATY = { W: 18, H: 14 } as const;
+export const PLATYPUS_START = 4;
+export const TIME_START = 80; // seconds on the bomb timer
 
-// Floaty water movement.
-const ACCEL = 560; // px/s² while a direction is held
-const DRAG = 3.2; // water resistance (low = floaty momentum)
-const MAX_SPEED = 155;
-const CURRENT_X = 34; // constant drift — you're always fighting the current
-const CURRENT_Y = 20;
+// Floaty water movement (a touch floatier + stronger current than before).
+const ACCEL = 560;
+const DRAG = 3.0;
+const MAX_SPEED = 168;
+const CURRENT_X = 40;
+const CURRENT_Y = 26;
 
-const RESPAWN_INVULN = 1.6; // seconds of safety after losing a turtle
-
-const START = { x: 18, y: 168 };
+const RESPAWN_INVULN = 1.4;
+const START = { x: 24, y: 338 };
 
 export type Rect = { x: number; y: number; w: number; h: number };
 export type Seaweed = Rect & { phase: number };
@@ -28,41 +28,44 @@ export type Bomb = { x: number; y: number; defused: boolean };
 export type Status = "playing" | "win" | "lose";
 export type LoseCause = "" | "time" | "dead";
 
-// --- Fixed level layout (hand-designed so it's always solvable) -----------
-// Gray dam walls with gaps; the gaps and chambers all hold electric seaweed.
+// --- Fixed maze layout (vertical dam walls w/ gaps → always solvable) ------
 export const WALLS: Rect[] = [
-  { x: 150, y: 0, w: 16, h: 120 },
-  { x: 150, y: 180, w: 16, h: 180 }, // gap y120..180
-  { x: 320, y: 0, w: 16, h: 200 },
-  { x: 320, y: 270, w: 16, h: 90 }, // gap y200..270
+  { x: 188, y: 0, w: 16, h: 120 }, { x: 188, y: 210, w: 16, h: 510 }, // gap 120..210
+  { x: 380, y: 0, w: 16, h: 470 }, { x: 380, y: 560, w: 16, h: 160 }, // gap 470..560
+  { x: 572, y: 0, w: 16, h: 230 }, { x: 572, y: 320, w: 16, h: 400 }, // gap 230..320
+  { x: 764, y: 0, w: 16, h: 430 }, { x: 764, y: 520, w: 16, h: 200 }, // gap 430..520
 ];
 
 export const SEAWEEDS: Seaweed[] = [
-  { x: 90, y: 0, w: 8, h: 150, phase: 0.0 },
-  { x: 112, y: 230, w: 8, h: 130, phase: 1.2 },
-  { x: 240, y: 0, w: 8, h: 120, phase: 0.6 },
-  { x: 210, y: 200, w: 8, h: 160, phase: 1.8 },
-  { x: 392, y: 0, w: 8, h: 160, phase: 0.3 },
-  { x: 420, y: 200, w: 8, h: 160, phase: 1.5 },
-  { x: 156, y: 120, w: 8, h: 60, phase: 0.9 }, // in wall-A gap
-  { x: 326, y: 200, w: 8, h: 70, phase: 0.4 }, // in wall-B gap
+  { x: 90, y: 0, w: 8, h: 300, phase: 0.0 },
+  { x: 120, y: 380, w: 8, h: 340, phase: 1.1 },
+  { x: 194, y: 120, w: 8, h: 90, phase: 0.6 }, // wall-1 gap
+  { x: 280, y: 0, w: 8, h: 240, phase: 0.9 },
+  { x: 300, y: 330, w: 8, h: 390, phase: 1.6 },
+  { x: 386, y: 470, w: 8, h: 90, phase: 0.3 }, // wall-2 gap
+  { x: 470, y: 0, w: 8, h: 200, phase: 1.3 },
+  { x: 500, y: 260, w: 8, h: 460, phase: 0.5 },
+  { x: 578, y: 230, w: 8, h: 90, phase: 1.0 }, // wall-3 gap
+  { x: 660, y: 0, w: 8, h: 380, phase: 0.4 },
+  { x: 690, y: 470, w: 8, h: 250, phase: 1.8 },
+  { x: 770, y: 430, w: 8, h: 90, phase: 0.7 }, // wall-4 gap
+  { x: 850, y: 0, w: 8, h: 300, phase: 1.2 },
+  { x: 880, y: 380, w: 8, h: 340, phase: 0.2 },
+  { x: 820, y: 330, w: 8, h: 120, phase: 1.5 },
 ];
 
 const BOMB_SPOTS: { x: number; y: number }[] = [
-  { x: 44, y: 60 },
-  { x: 60, y: 305 },
-  { x: 200, y: 60 },
-  { x: 232, y: 145 },
-  { x: 250, y: 310 },
-  { x: 380, y: 90 },
-  { x: 404, y: 184 },
-  { x: 432, y: 300 },
+  { x: 60, y: 60 }, { x: 70, y: 420 }, { x: 140, y: 650 },
+  { x: 300, y: 140 }, { x: 330, y: 640 },
+  { x: 470, y: 400 }, { x: 520, y: 120 }, { x: 540, y: 650 },
+  { x: 660, y: 200 }, { x: 700, y: 560 },
+  { x: 860, y: 150 }, { x: 900, y: 640 },
 ];
 
-// Electric seaweed cycle: mostly safe, brief warning, then a deadly zap.
-const SW_CYCLE = 2.4;
-const SW_WARN = 1.6;
-const SW_ZAP = 1.95;
+// Electric seaweed cycle — harder: longer deadly window, shorter warning.
+const SW_CYCLE = 2.0;
+const SW_WARN = 1.2;
+const SW_ZAP = 1.45;
 /** 0 = safe, 1 = warning (about to zap), 2 = zapping (deadly). */
 export function seaweedState(time: number, sw: Seaweed): 0 | 1 | 2 {
   const t = (time + sw.phase * 0.83) % SW_CYCLE;
@@ -78,15 +81,15 @@ export type Game = {
   y: number;
   vx: number;
   vy: number;
-  facing: 1 | -1; // last horizontal heading, for drawing
+  facing: 1 | -1;
   bombs: Bomb[];
-  turtles: number; // turtles remaining (current one included)
+  platypuses: number;
   time: number;
   status: Status;
   cause: LoseCause;
   invuln: number;
-  gameTime: number; // drives seaweed pulsing
-  flash: number; // brief red flash timer on a death
+  gameTime: number;
+  flash: number;
 };
 
 function overlaps(
@@ -107,7 +110,7 @@ export function createGame(): Game {
     vy: 0,
     facing: 1,
     bombs: BOMB_SPOTS.map((s) => ({ x: s.x, y: s.y, defused: false })),
-    turtles: TURTLES_START,
+    platypuses: PLATYPUS_START,
     time: TIME_START,
     status: "playing",
     cause: "",
@@ -127,11 +130,11 @@ function respawn(g: Game) {
   g.invuln = RESPAWN_INVULN;
 }
 
-function killTurtle(g: Game) {
-  g.turtles -= 1;
+function killPlatypus(g: Game) {
+  g.platypuses -= 1;
   g.flash = 0.25;
-  if (g.turtles <= 0) {
-    g.turtles = 0;
+  if (g.platypuses <= 0) {
+    g.platypuses = 0;
     g.status = "lose";
     g.cause = "dead";
   } else {
@@ -146,7 +149,6 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
   if (g.flash > 0) g.flash = Math.max(0, g.flash - dt);
   if (g.invuln > 0) g.invuln = Math.max(0, g.invuln - dt);
 
-  // Movement: held direction + current, with floaty drag.
   const ix = (input.right ? 1 : 0) - (input.left ? 1 : 0);
   const iy = (input.down ? 1 : 0) - (input.up ? 1 : 0);
   g.vx += (ix * ACCEL + CURRENT_X) * dt;
@@ -161,58 +163,43 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
   }
   if (ix !== 0) g.facing = ix > 0 ? 1 : -1;
 
-  // Integrate + resolve, one axis at a time so wall sliding feels right.
+  // Integrate + resolve, one axis at a time.
   g.x += g.vx * dt;
-  if (g.x < 0) {
-    g.x = 0;
-    g.vx = 0;
-  }
-  if (g.x > VIRT.W - TURTLE.W) {
-    g.x = VIRT.W - TURTLE.W;
-    g.vx = 0;
-  }
+  if (g.x < 0) { g.x = 0; g.vx = 0; }
+  if (g.x > WORLD.W - PLATY.W) { g.x = WORLD.W - PLATY.W; g.vx = 0; }
   for (const w of WALLS) {
-    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, w)) {
-      if (g.vx > 0) g.x = w.x - TURTLE.W;
+    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, w)) {
+      if (g.vx > 0) g.x = w.x - PLATY.W;
       else if (g.vx < 0) g.x = w.x + w.w;
       g.vx = 0;
     }
   }
   g.y += g.vy * dt;
-  if (g.y < 0) {
-    g.y = 0;
-    g.vy = 0;
-  }
-  if (g.y > VIRT.H - TURTLE.H) {
-    g.y = VIRT.H - TURTLE.H;
-    g.vy = 0;
-  }
+  if (g.y < 0) { g.y = 0; g.vy = 0; }
+  if (g.y > WORLD.H - PLATY.H) { g.y = WORLD.H - PLATY.H; g.vy = 0; }
   for (const w of WALLS) {
-    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, w)) {
-      if (g.vy > 0) g.y = w.y - TURTLE.H;
+    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, w)) {
+      if (g.vy > 0) g.y = w.y - PLATY.H;
       else if (g.vy < 0) g.y = w.y + w.h;
       g.vy = 0;
     }
   }
 
-  // Electric seaweed (deadly only mid-zap; harmless while invulnerable).
+  // Electric seaweed.
   if (g.invuln <= 0) {
     for (const sw of SEAWEEDS) {
-      if (
-        seaweedState(g.gameTime, sw) === 2 &&
-        overlaps(g.x, g.y, TURTLE.W, TURTLE.H, sw)
-      ) {
-        killTurtle(g);
+      if (seaweedState(g.gameTime, sw) === 2 && overlaps(g.x, g.y, PLATY.W, PLATY.H, sw)) {
+        killPlatypus(g);
         break;
       }
     }
   }
   if (g.status !== "playing") return g;
 
-  // Defuse bombs on contact.
+  // Defuse bombs.
   for (const b of g.bombs) {
     if (b.defused) continue;
-    if (overlaps(g.x, g.y, TURTLE.W, TURTLE.H, { x: b.x - 8, y: b.y - 8, w: 16, h: 16 })) {
+    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, { x: b.x - 8, y: b.y - 8, w: 16, h: 16 })) {
       b.defused = true;
     }
   }
@@ -221,7 +208,6 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
     return g;
   }
 
-  // The bomb timer.
   g.time -= dt;
   if (g.time <= 0) {
     g.time = 0;
@@ -231,14 +217,13 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
   return g;
 }
 
-/** A cheeky end-of-run line. */
 export function endMessage(g: Game): string {
   if (g.status === "win") {
-    if (g.turtles >= 4) return "Not a scratch. Suspicious.";
-    if (g.turtles === 3) return "Down a turtle already. The dam's just warming up.";
-    if (g.turtles === 2) return "Two turtles left. The seaweed ate the rest.";
-    return "One turtle left to beat the ENTIRE rest of the game. Classic.";
+    if (g.platypuses >= 4) return "Not a scratch. Suspicious.";
+    if (g.platypuses === 3) return "Down a platypus already. The dam's just warming up.";
+    if (g.platypuses === 2) return "Two platypuses left. The seaweed ate the rest.";
+    return "One platypus left to beat the ENTIRE rest of the game. Classic.";
   }
   if (g.cause === "time") return "💥 The dam blew. Should've swum faster.";
-  return "All four turtles fried by the seaweed. The dam wins again.";
+  return "All four platypuses fried by the seaweed. The damn level wins again.";
 }


### PR DESCRIPTION
Reworks the dam game per request:

- **Renamed** "The Dam Level" → **"The Damn Level"** (route `/damn-level`).
- **Platypuses** instead of turtles — new sprite (brown body, duck bill, flat tail, colored headband per critter) and all copy/lives/messages updated.
- **Bigger, more faithful map:** the world is now a **960×720 dam maze** (four vertical dam walls with offset gaps) and a **camera follows you in all four directions**, instead of one static screen.
- **Harder:** **12 bombs** (was 8), **15 electric-seaweed strands** with a longer deadly zap window + shorter warning, stronger current, floatier drag, shorter respawn invulnerability, and an 80s timer for the larger map.

Hand-designed and smoke-tested: win path, time-loss path, and bomb placement (in-bounds, never buried in a wall) all verified. Typecheck + build pass.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_