### PR TITLE
The Damn Level: rebuild the map as a tunnel system

### DIFF
--- a/components/damlevel/DamLevel.tsx
+++ b/components/damlevel/DamLevel.tsx
@@ -5,8 +5,9 @@ import { Play, RotateCcw } from "lucide-react";
 import {
   WORLD,
   PLATY,
-  WALLS,
-  SEAWEEDS,
+  TILE,
+  COLS,
+  ROWS,
   PLATYPUS_START,
   type Game,
   type Input,
@@ -15,6 +16,7 @@ import {
   seaweedState,
   bombsLeft,
   endMessage,
+  solidAt,
 } from "@/lib/damlevel";
 
 type Phase = "menu" | "playing" | "win" | "lose";
@@ -312,19 +314,36 @@ function draw(ctx: CanvasRenderingContext2D, g: Game | null, bubbles: Bubble[]) 
   ctx.save();
   ctx.translate(-camX, -camY);
 
-  for (const w of WALLS) {
-    ctx.fillStyle = "#5b6675";
-    ctx.fillRect(w.x, w.y, w.w, w.h);
-    ctx.fillStyle = "#454e5b";
-    ctx.fillRect(w.x, w.y, 3, w.h);
-    ctx.fillStyle = "#7a8694";
-    for (let ry = w.y + 8; ry < w.y + w.h - 4; ry += 18) {
-      ctx.fillRect(w.x + w.w / 2 - 1, ry, 2, 2);
+  // Solid rock tiles (only the visible ones).
+  if (g) {
+    const c0 = Math.max(0, Math.floor(camX / TILE));
+    const c1 = Math.min(COLS - 1, Math.floor((camX + VIEW.W) / TILE));
+    const r0 = Math.max(0, Math.floor(camY / TILE));
+    const r1 = Math.min(ROWS - 1, Math.floor((camY + VIEW.H) / TILE));
+    for (let r = r0; r <= r1; r++) {
+      for (let c = c0; c <= c1; c++) {
+        if (!solidAt(g, c, r)) continue;
+        const x = c * TILE, y = r * TILE;
+        ctx.fillStyle = "#3a4654";
+        ctx.fillRect(x, y, TILE, TILE);
+        // lighter top edge where a tunnel is above (depth)
+        if (!solidAt(g, c, r - 1)) {
+          ctx.fillStyle = "#566275";
+          ctx.fillRect(x, y, TILE, 3);
+        }
+        ctx.fillStyle = "#2c3642";
+        ctx.fillRect(x, y, TILE, 1);
+        ctx.fillRect(x, y, 1, TILE);
+        // a couple of rivets
+        ctx.fillStyle = "#4a5666";
+        ctx.fillRect(x + 10, y + 12, 2, 2);
+        ctx.fillRect(x + TILE - 14, y + TILE - 16, 2, 2);
+      }
     }
   }
 
   if (g) {
-    for (const sw of SEAWEEDS) {
+    for (const sw of g.seaweeds) {
       const st = seaweedState(g.gameTime, sw);
       let col = "#2f9e44";
       if (st === 2) col = Math.floor(g.gameTime * 30) % 2 ? "#ffffff" : "#ffe04d";

--- a/lib/damlevel.ts
+++ b/lib/damlevel.ts
@@ -1,68 +1,59 @@
 // Game logic for "The Damn Level" — a homage to the infamous underwater dam
-// stage from the 1989 TMNT NES game, only with platypuses. The world is a
-// large scrolling maze (the camera follows you in all four directions); swim
-// the floaty current, defuse every bomb before the timer blows the dam, and
-// weave through deadly electric seaweed. You get four platypuses. The seaweed
-// will take most of them.
+// stage from the 1989 TMNT NES game, with platypuses. The map is a generated
+// network of narrow tunnels carved through rock (a braided maze, so it's fully
+// connected and always solvable). Swim the floaty current through the tunnels,
+// defuse every bomb before the timer blows the dam, and weave past electric
+// seaweed that gates the corridors. You get four platypuses; the seaweed will
+// take most of them — and each death drops you back at the entrance.
 
-// The whole level — bigger than the viewport, so the camera scrolls.
-export const WORLD = { W: 960, H: 720 } as const;
+export const TILE = 44;
+export const COLS = 21; // odd → maze grid
+export const ROWS = 15;
+export const WORLD = { W: COLS * TILE, H: ROWS * TILE } as const; // 924 x 660
 
 export const PLATY = { W: 18, H: 14 } as const;
 export const PLATYPUS_START = 4;
-export const TIME_START = 80; // seconds on the bomb timer
+export const TIME_START = 100; // seconds on the bomb timer
 
-// Floaty water movement (a touch floatier + stronger current than before).
-const ACCEL = 560;
-const DRAG = 3.0;
-const MAX_SPEED = 168;
-const CURRENT_X = 40;
-const CURRENT_Y = 26;
+const BOMB_COUNT = 12;
+const SEAWEED_COUNT = 14;
 
-const RESPAWN_INVULN = 1.4;
-const START = { x: 24, y: 338 };
+// Floaty water movement — controllable enough for tunnels, never still.
+const ACCEL = 640;
+const DRAG = 4.2;
+const MAX_SPEED = 158;
+const CURRENT_X = 26;
+const CURRENT_Y = 16;
+
+const RESPAWN_INVULN = 1.5;
 
 export type Rect = { x: number; y: number; w: number; h: number };
 export type Seaweed = Rect & { phase: number };
 export type Bomb = { x: number; y: number; defused: boolean };
 export type Status = "playing" | "win" | "lose";
 export type LoseCause = "" | "time" | "dead";
+export type Input = { up: boolean; down: boolean; left: boolean; right: boolean };
 
-// --- Fixed maze layout (vertical dam walls w/ gaps → always solvable) ------
-export const WALLS: Rect[] = [
-  { x: 188, y: 0, w: 16, h: 120 }, { x: 188, y: 210, w: 16, h: 510 }, // gap 120..210
-  { x: 380, y: 0, w: 16, h: 470 }, { x: 380, y: 560, w: 16, h: 160 }, // gap 470..560
-  { x: 572, y: 0, w: 16, h: 230 }, { x: 572, y: 320, w: 16, h: 400 }, // gap 230..320
-  { x: 764, y: 0, w: 16, h: 430 }, { x: 764, y: 520, w: 16, h: 200 }, // gap 430..520
-];
+export type Game = {
+  grid: Uint8Array; // ROWS*COLS, 1 = solid rock, 0 = tunnel
+  bombs: Bomb[];
+  seaweeds: Seaweed[];
+  startX: number;
+  startY: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  facing: 1 | -1;
+  platypuses: number;
+  time: number;
+  status: Status;
+  cause: LoseCause;
+  invuln: number;
+  gameTime: number;
+  flash: number;
+};
 
-export const SEAWEEDS: Seaweed[] = [
-  { x: 90, y: 0, w: 8, h: 300, phase: 0.0 },
-  { x: 120, y: 380, w: 8, h: 340, phase: 1.1 },
-  { x: 194, y: 120, w: 8, h: 90, phase: 0.6 }, // wall-1 gap
-  { x: 280, y: 0, w: 8, h: 240, phase: 0.9 },
-  { x: 300, y: 330, w: 8, h: 390, phase: 1.6 },
-  { x: 386, y: 470, w: 8, h: 90, phase: 0.3 }, // wall-2 gap
-  { x: 470, y: 0, w: 8, h: 200, phase: 1.3 },
-  { x: 500, y: 260, w: 8, h: 460, phase: 0.5 },
-  { x: 578, y: 230, w: 8, h: 90, phase: 1.0 }, // wall-3 gap
-  { x: 660, y: 0, w: 8, h: 380, phase: 0.4 },
-  { x: 690, y: 470, w: 8, h: 250, phase: 1.8 },
-  { x: 770, y: 430, w: 8, h: 90, phase: 0.7 }, // wall-4 gap
-  { x: 850, y: 0, w: 8, h: 300, phase: 1.2 },
-  { x: 880, y: 380, w: 8, h: 340, phase: 0.2 },
-  { x: 820, y: 330, w: 8, h: 120, phase: 1.5 },
-];
-
-const BOMB_SPOTS: { x: number; y: number }[] = [
-  { x: 60, y: 60 }, { x: 70, y: 420 }, { x: 140, y: 650 },
-  { x: 300, y: 140 }, { x: 330, y: 640 },
-  { x: 470, y: 400 }, { x: 520, y: 120 }, { x: 540, y: 650 },
-  { x: 660, y: 200 }, { x: 700, y: 560 },
-  { x: 860, y: 150 }, { x: 900, y: 640 },
-];
-
-// Electric seaweed cycle — harder: longer deadly window, shorter warning.
 const SW_CYCLE = 2.0;
 const SW_WARN = 1.2;
 const SW_ZAP = 1.45;
@@ -74,42 +65,147 @@ export function seaweedState(time: number, sw: Seaweed): 0 | 1 | 2 {
   return 2;
 }
 
-export type Input = { up: boolean; down: boolean; left: boolean; right: boolean };
-
-export type Game = {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  facing: 1 | -1;
-  bombs: Bomb[];
-  platypuses: number;
-  time: number;
-  status: Status;
-  cause: LoseCause;
-  invuln: number;
-  gameTime: number;
-  flash: number;
-};
-
-function overlaps(
-  ax: number,
-  ay: number,
-  aw: number,
-  ah: number,
-  b: Rect,
-): boolean {
-  return ax < b.x + b.w && ax + aw > b.x && ay < b.y + b.h && ay + ah > b.y;
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
 }
 
-export function createGame(): Game {
+export const solidAt = (g: Game, col: number, row: number): boolean =>
+  col < 0 || col >= COLS || row < 0 || row >= ROWS || g.grid[row * COLS + col] === 1;
+
+const DIRS = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+// Carve a braided maze of tunnels and place bombs + seaweed.
+function buildLevel(rand: () => number) {
+  const grid = new Uint8Array(ROWS * COLS).fill(1);
+  const at = (r: number, c: number) => r * COLS + c;
+  const CR = (ROWS - 1) / 2; // 7 cell rows
+  const CC = (COLS - 1) / 2; // 10 cell cols
+  const vis = Array.from({ length: CR }, () => new Array(CC).fill(false));
+  const tr = (cr: number) => 2 * cr + 1;
+  const tc = (cc: number) => 2 * cc + 1;
+
+  // Recursive backtracker (iterative).
+  const stack: [number, number][] = [[0, 0]];
+  vis[0][0] = true;
+  grid[at(tr(0), tc(0))] = 0;
+  while (stack.length) {
+    const [cr, cc] = stack[stack.length - 1];
+    const opts: [number, number, number, number][] = [];
+    for (const [dr, dc] of DIRS) {
+      const nr = cr + dr, nc = cc + dc;
+      if (nr >= 0 && nr < CR && nc >= 0 && nc < CC && !vis[nr][nc]) opts.push([nr, nc, dr, dc]);
+    }
+    if (!opts.length) {
+      stack.pop();
+      continue;
+    }
+    const [nr, nc, dr, dc] = opts[Math.floor(rand() * opts.length)];
+    vis[nr][nc] = true;
+    grid[at(tr(nr), tc(nc))] = 0;
+    grid[at(tr(cr) + dr, tc(cc) + dc)] = 0; // knock down the wall between
+    stack.push([nr, nc]);
+  }
+
+  // Braid: open ~35% of dead-ends to create loops → an interconnected tunnel
+  // system rather than a tedious perfect maze.
+  for (let cr = 0; cr < CR; cr++) {
+    for (let cc = 0; cc < CC; cc++) {
+      const r = tr(cr), c = tc(cc);
+      let open = 0;
+      const walls: [number, number, number, number][] = [];
+      for (const [dr, dc] of DIRS) {
+        if (grid[at(r + dr, c + dc)] === 0) open++;
+        else walls.push([r + dr, c + dc, dr, dc]);
+      }
+      if (open === 1 && rand() < 0.35) {
+        const valid = walls.filter(([, , dr, dc]) => {
+          const ncr = cr + dr, ncc = cc + dc;
+          return ncr >= 0 && ncr < CR && ncc >= 0 && ncc < CC;
+        });
+        if (valid.length) {
+          const [wr, wc] = valid[Math.floor(rand() * valid.length)];
+          grid[at(wr, wc)] = 0;
+        }
+      }
+    }
+  }
+
+  const shuffle = <T,>(a: T[]) => {
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(rand() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  };
+
+  const startR = tr(0), startC = tc(0);
+
+  // Bombs — prefer dead-end cells (a tunnel you have to go down), then others.
+  const cells: [number, number][] = [];
+  for (let cr = 0; cr < CR; cr++) for (let cc = 0; cc < CC; cc++) cells.push([tr(cr), tc(cc)]);
+  const openCount = (r: number, c: number) =>
+    DIRS.reduce((n, [dr, dc]) => n + (grid[at(r + dr, c + dc)] === 0 ? 1 : 0), 0);
+  const deadEnds = cells.filter(([r, c]) => openCount(r, c) === 1 && !(r === startR && c === startC));
+  const others = cells.filter(([r, c]) => !(openCount(r, c) === 1) && !(r === startR && c === startC));
+  const order = shuffle(deadEnds).concat(shuffle(others));
+  const bombs: Bomb[] = [];
+  for (const [r, c] of order) {
+    if (bombs.length >= BOMB_COUNT) break;
+    bombs.push({ x: c * TILE + TILE / 2, y: r * TILE + TILE / 2, defused: false });
+  }
+
+  // Seaweed — gate corridors (open tiles between two cells), away from the start.
+  const connectors: { r: number; c: number; vertical: boolean }[] = [];
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (grid[at(r, c)] !== 0) continue;
+      if (r % 2 === 1 && c % 2 === 1) continue; // skip cell centers
+      const vertical = grid[at(r - 1, c)] === 0 || grid[at(r + 1, c)] === 0;
+      if (Math.abs(r - startR) + Math.abs(c - startC) > 2) connectors.push({ r, c, vertical });
+    }
+  }
+  const seaweeds: Seaweed[] = [];
+  for (const k of shuffle(connectors).slice(0, SEAWEED_COUNT)) {
+    const tx = k.c * TILE, ty = k.r * TILE;
+    if (k.vertical) seaweeds.push({ x: tx + 4, y: ty + TILE / 2 - 5, w: TILE - 8, h: 10, phase: rand() * 2 });
+    else seaweeds.push({ x: tx + TILE / 2 - 5, y: ty + 4, w: 10, h: TILE - 8, phase: rand() * 2 });
+  }
+
   return {
-    x: START.x,
-    y: START.y,
+    grid,
+    bombs,
+    seaweeds,
+    startX: startC * TILE + TILE / 2 - PLATY.W / 2,
+    startY: startR * TILE + TILE / 2 - PLATY.H / 2,
+  };
+}
+
+export function createGame(seed?: number): Game {
+  const rand = seed === undefined ? Math.random : mulberry32(seed);
+  const lvl = buildLevel(rand);
+  return {
+    grid: lvl.grid,
+    bombs: lvl.bombs,
+    seaweeds: lvl.seaweeds,
+    startX: lvl.startX,
+    startY: lvl.startY,
+    x: lvl.startX,
+    y: lvl.startY,
     vx: 0,
     vy: 0,
     facing: 1,
-    bombs: BOMB_SPOTS.map((s) => ({ x: s.x, y: s.y, defused: false })),
     platypuses: PLATYPUS_START,
     time: TIME_START,
     status: "playing",
@@ -122,12 +218,8 @@ export function createGame(): Game {
 
 export const bombsLeft = (g: Game) => g.bombs.filter((b) => !b.defused).length;
 
-function respawn(g: Game) {
-  g.x = START.x;
-  g.y = START.y;
-  g.vx = 0;
-  g.vy = 0;
-  g.invuln = RESPAWN_INVULN;
+function overlaps(ax: number, ay: number, aw: number, ah: number, b: Rect): boolean {
+  return ax < b.x + b.w && ax + aw > b.x && ay < b.y + b.h && ay + ah > b.y;
 }
 
 function killPlatypus(g: Game) {
@@ -138,7 +230,11 @@ function killPlatypus(g: Game) {
     g.status = "lose";
     g.cause = "dead";
   } else {
-    respawn(g);
+    g.x = g.startX;
+    g.y = g.startY;
+    g.vx = 0;
+    g.vy = 0;
+    g.invuln = RESPAWN_INVULN;
   }
 }
 
@@ -163,31 +259,37 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
   }
   if (ix !== 0) g.facing = ix > 0 ? 1 : -1;
 
-  // Integrate + resolve, one axis at a time.
+  // Tile collision, axis-separated.
   g.x += g.vx * dt;
   if (g.x < 0) { g.x = 0; g.vx = 0; }
   if (g.x > WORLD.W - PLATY.W) { g.x = WORLD.W - PLATY.W; g.vx = 0; }
-  for (const w of WALLS) {
-    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, w)) {
-      if (g.vx > 0) g.x = w.x - PLATY.W;
-      else if (g.vx < 0) g.x = w.x + w.w;
-      g.vx = 0;
+  {
+    const r0 = Math.floor(g.y / TILE), r1 = Math.floor((g.y + PLATY.H - 1) / TILE);
+    if (g.vx > 0) {
+      const c = Math.floor((g.x + PLATY.W - 1) / TILE);
+      for (let r = r0; r <= r1; r++) if (solidAt(g, c, r)) { g.x = c * TILE - PLATY.W; g.vx = 0; break; }
+    } else if (g.vx < 0) {
+      const c = Math.floor(g.x / TILE);
+      for (let r = r0; r <= r1; r++) if (solidAt(g, c, r)) { g.x = (c + 1) * TILE; g.vx = 0; break; }
     }
   }
   g.y += g.vy * dt;
   if (g.y < 0) { g.y = 0; g.vy = 0; }
   if (g.y > WORLD.H - PLATY.H) { g.y = WORLD.H - PLATY.H; g.vy = 0; }
-  for (const w of WALLS) {
-    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, w)) {
-      if (g.vy > 0) g.y = w.y - PLATY.H;
-      else if (g.vy < 0) g.y = w.y + w.h;
-      g.vy = 0;
+  {
+    const c0 = Math.floor(g.x / TILE), c1 = Math.floor((g.x + PLATY.W - 1) / TILE);
+    if (g.vy > 0) {
+      const r = Math.floor((g.y + PLATY.H - 1) / TILE);
+      for (let c = c0; c <= c1; c++) if (solidAt(g, c, r)) { g.y = r * TILE - PLATY.H; g.vy = 0; break; }
+    } else if (g.vy < 0) {
+      const r = Math.floor(g.y / TILE);
+      for (let c = c0; c <= c1; c++) if (solidAt(g, c, r)) { g.y = (r + 1) * TILE; g.vy = 0; break; }
     }
   }
 
   // Electric seaweed.
   if (g.invuln <= 0) {
-    for (const sw of SEAWEEDS) {
+    for (const sw of g.seaweeds) {
       if (seaweedState(g.gameTime, sw) === 2 && overlaps(g.x, g.y, PLATY.W, PLATY.H, sw)) {
         killPlatypus(g);
         break;
@@ -196,12 +298,9 @@ export function updateGame(g: Game, dt: number, input: Input): Game {
   }
   if (g.status !== "playing") return g;
 
-  // Defuse bombs.
   for (const b of g.bombs) {
     if (b.defused) continue;
-    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, { x: b.x - 8, y: b.y - 8, w: 16, h: 16 })) {
-      b.defused = true;
-    }
+    if (overlaps(g.x, g.y, PLATY.W, PLATY.H, { x: b.x - 9, y: b.y - 9, w: 18, h: 18 })) b.defused = true;
   }
   if (bombsLeft(g) === 0) {
     g.status = "win";


### PR DESCRIPTION
Rebuilds The Damn Level's map as a **tunnel system**, much closer to the actual TMNT dam stage.

- Replaces the open-column layout with a **generated network of narrow tunnels carved through rock** — a braided maze (recursive backtracker + ~35% dead-end removal) on a 21×15 tile grid (924×660 world). Braiding makes it an **interconnected tunnel system** with multiple routes rather than a tedious perfect maze, and guarantees full connectivity.
- **Tile-based collision** so the platypus swims the corridors and bonks solid rock; the camera still scrolls in all four directions.
- **12 bombs** tucked in tunnels (dead-ends preferred) and **14 electric-seaweed strands gating the corridors**. A **fresh maze each run**.
- Movement tuned a touch tighter (more drag, gentler current) so the narrow tunnels stay fair; deaths still drop you back at the entrance (the authentic pain).

**Verified across 400 seeds:** every open tile reachable from the entrance (reachable-open fraction = 1.000), every bomb reachable, no bomb/seaweed buried in rock, and the win path holds. Typecheck + build pass.

https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvHk5oDVP6N5MSbiv6jFTx)_